### PR TITLE
Dt 2880 probation documents protected by caseload

### DIFF
--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -133,7 +133,7 @@ const setup = ({
   )
   router.get(
     '/offenders/:offenderNo/probation-documents/:documentId/download',
-    downloadProbationDocumentFactory(oauthApi, communityApi, systemOauthClient).downloadDocument
+    downloadProbationDocumentFactory(oauthApi, communityApi, systemOauthClient, prisonApi).downloadDocument
   )
 
   router.get('/bulk-appointments/need-to-upload-file', async (req, res) => {

--- a/backend/services/prisonerProfileService.ts
+++ b/backend/services/prisonerProfileService.ts
@@ -6,6 +6,7 @@ import { alertFlagLabels, profileAlertCodes } from '../shared/alertFlagValues'
 import { csraTranslations } from '../shared/csraHelpers'
 import config from '../config'
 import logErrorAndContinue from '../shared/logErrorAndContinue'
+import canAccessProbationDocuments from '../shared/probationDocumentsAccess'
 
 export const isComplexityEnabledFor = (agencyId) => config.apis.complexity.enabled_prisons?.includes(agencyId)
 
@@ -112,10 +113,10 @@ export default ({
         )
     )
 
-    const canViewProbationDocuments = Boolean(
-      offenderInCaseload &&
-        userRoles &&
-        (userRoles as any).some((role) => ['VIEW_PROBATION_DOCUMENTS', 'POM'].includes(role.roleCode))
+    const canViewProbationDocuments = canAccessProbationDocuments(
+      userRoles as [{ roleCode: string }],
+      userCaseloads as [{ caseLoadId: string }],
+      agencyId
     )
 
     const isPathfinderUser = Boolean(

--- a/backend/services/prisonerProfileService.ts
+++ b/backend/services/prisonerProfileService.ts
@@ -113,7 +113,9 @@ export default ({
     )
 
     const canViewProbationDocuments = Boolean(
-      userRoles && (userRoles as any).some((role) => ['VIEW_PROBATION_DOCUMENTS', 'POM'].includes(role.roleCode))
+      offenderInCaseload &&
+        userRoles &&
+        (userRoles as any).some((role) => ['VIEW_PROBATION_DOCUMENTS', 'POM'].includes(role.roleCode))
     )
 
     const isPathfinderUser = Boolean(

--- a/backend/shared/probationDocumentsAccess.ts
+++ b/backend/shared/probationDocumentsAccess.ts
@@ -1,0 +1,16 @@
+import exp from 'constants'
+
+const canAccessProbationDocuments = (
+  userRoles: [{ roleCode: string }],
+  caseloads: [{ caseLoadId }],
+  agencyId: string
+): boolean => {
+  const offenderInCaseload =
+    caseloads && (caseloads as [{ caseLoadId: string }]).some((caseload) => caseload.caseLoadId === agencyId)
+  const hasCorrectRole =
+    userRoles && userRoles.find((role) => role.roleCode === 'VIEW_PROBATION_DOCUMENTS' || role.roleCode === 'POM')
+
+  return offenderInCaseload && !!hasCorrectRole
+}
+
+export default canAccessProbationDocuments

--- a/backend/shared/probationDocumentsAccess.ts
+++ b/backend/shared/probationDocumentsAccess.ts
@@ -1,5 +1,3 @@
-import exp from 'constants'
-
 const canAccessProbationDocuments = (
   userRoles: [{ roleCode: string }],
   caseloads: [{ caseLoadId }],

--- a/backend/tests/downloadProbationDocument.test.ts
+++ b/backend/tests/downloadProbationDocument.test.ts
@@ -2,6 +2,7 @@ import { downloadProbationDocumentFactory } from '../controllers/downloadProbati
 
 describe('Download probation documents', () => {
   const oauthApi = {}
+  const prisonApi = {}
   const communityApi = {}
   const systemOauthClient = {}
 
@@ -15,6 +16,10 @@ describe('Download probation documents', () => {
       oauthApi.userRoles = jest.fn()
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'currentUser' does not exist on type '{}'... Remove this comment to see the full error message
       oauthApi.currentUser = jest.fn()
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'userCaseLoads' does not exist on type '{}'... Remove this comment to see the full error message
+      prisonApi.userCaseLoads = jest.fn()
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'getDetails' does not exist on type '{}'... Remove this comment to see the full error message
+      prisonApi.getDetails = jest.fn()
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'pipeOffenderDocument' does not exist on ... Remove this comment to see the full error message
       communityApi.pipeOffenderDocument = jest.fn()
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getClientCredentialsTokens' does not exi... Remove this comment to see the full error message
@@ -25,7 +30,13 @@ describe('Download probation documents', () => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'userRoles' does not exist on type '{}'.
       oauthApi.userRoles.mockReturnValue([{ roleCode: 'POM' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'currentUser' does not exist on type '{}'... Remove this comment to see the full error message
-      oauthApi.currentUser.mockReturnValue({ username: 'USER_ADM' })
+      oauthApi.currentUser.mockReturnValue({ username: 'USER_ADM', activeCaseLoadId: 'MDI' })
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'userCaseLoads' does not exist on type '{}'... Remove this comment to see the full error message
+      prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+      // @ts-expect-error ts-migrate(2339)
+      prisonApi.getDetails.mockReturnValue({
+        agencyId: 'LEI',
+      })
     })
 
     describe('when downloading document', () => {
@@ -34,7 +45,7 @@ describe('Download probation documents', () => {
       let page
 
       beforeEach(() => {
-        page = downloadProbationDocumentFactory(oauthApi, communityApi, systemOauthClient).downloadDocument
+        page = downloadProbationDocumentFactory(oauthApi, communityApi, systemOauthClient, prisonApi).downloadDocument
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'render' does not exist on type '{}'.
         res.render = jest.fn()
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'locals' does not exist on type '{}'.
@@ -60,15 +71,66 @@ describe('Download probation documents', () => {
         )
       })
 
-      it('should render page with unavailable message with missing role', async () => {
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'userRoles' does not exist on type '{}'.
-        oauthApi.userRoles.mockReturnValue([{ roleCode: 'SOME_OTHER_ROLE' }])
+      describe('access to the download is based on role and caseload', () => {
+        it('should allow download if prisoner in one of my other caseloads but not the active one', async () => {
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.getDetails.mockReturnValue({
+            agencyId: 'LEI',
+          })
 
-        const error = new Error('You do not have the correct role to access this page')
+          await page(req, res)
 
-        await expect(page(req, res)).rejects.toThrowError(error)
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'locals' does not exist on type '{}'.
-        expect(res.locals.redirectUrl).toBe('/offenders/G9542VP/probation-documents')
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'pipeOffenderDocument' does not exist on ... Remove this comment to see the full error message
+          expect(communityApi.pipeOffenderDocument).toHaveBeenCalled()
+        })
+        it('should render page with unavailable message with missing role', async () => {
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'userRoles' does not exist on type '{}'.
+          oauthApi.userRoles.mockReturnValue([{ roleCode: 'SOME_OTHER_ROLE' }])
+
+          const error = new Error('You do not have the correct role or caseload to access this page')
+
+          await expect(page(req, res)).rejects.toThrowError(error)
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'locals' does not exist on type '{}'.
+          expect(res.locals.redirectUrl).toBe('/offenders/G9542VP/probation-documents')
+        })
+
+        it('should render page with unavailable message when prisoner is not in any of my caseloads', async () => {
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.getDetails.mockReturnValue({
+            agencyId: 'BXI',
+          })
+
+          const error = new Error('You do not have the correct role or caseload to access this page')
+
+          await expect(page(req, res)).rejects.toThrowError(error)
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'locals' does not exist on type '{}'.
+          expect(res.locals.redirectUrl).toBe('/offenders/G9542VP/probation-documents')
+        })
+
+        it('should render page with unavailable message when prisoner is now out of prison', async () => {
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.getDetails.mockReturnValue({
+            agencyId: 'OUT',
+          })
+
+          const error = new Error('You do not have the correct role or caseload to access this page')
+
+          await expect(page(req, res)).rejects.toThrowError(error)
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'locals' does not exist on type '{}'.
+          expect(res.locals.redirectUrl).toBe('/offenders/G9542VP/probation-documents')
+        })
       })
     })
   })

--- a/backend/tests/prisonerProfileService.test.ts
+++ b/backend/tests/prisonerProfileService.test.ts
@@ -483,14 +483,78 @@ describe('prisoner profile service', () => {
           oauthApi.userRoles.mockResolvedValue([{ roleCode: 'VIEW_PROBATION_DOCUMENTS' }])
         })
 
-        it('should let the user view probation documents', async () => {
-          const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+        describe('when prisoner is in active caseload', () => {
+          beforeEach(() => {
+            // @ts-expect-error ts-migrate(2339)
+            prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+            // @ts-expect-error ts-migrate(2339)
+            oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+          })
+          it('should let the user view probation documents', async () => {
+            const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
 
-          expect(getPrisonerProfileData).toEqual(
-            expect.objectContaining({
-              canViewProbationDocuments: true,
+            expect(getPrisonerProfileData).toEqual(
+              expect.objectContaining({
+                canViewProbationDocuments: true,
+              })
+            )
+          })
+        })
+        describe('when prisoner is in another one for your caseload', () => {
+          beforeEach(() => {
+            // @ts-expect-error ts-migrate(2339)
+            prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }])
+            // @ts-expect-error ts-migrate(2339)
+            oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'LEI' })
+          })
+          it('should let the user view probation documents', async () => {
+            const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+
+            expect(getPrisonerProfileData).toEqual(
+              expect.objectContaining({
+                canViewProbationDocuments: true,
+              })
+            )
+          })
+        })
+        describe('when prisoner is not in any of your caseloads', () => {
+          beforeEach(() => {
+            // @ts-expect-error ts-migrate(2339)
+            prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'BXI' }, { caseLoadId: 'WWI' }])
+            // @ts-expect-error ts-migrate(2339)
+            oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'BXI' })
+          })
+          it('should let the user view probation documents', async () => {
+            const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+
+            expect(getPrisonerProfileData).toEqual(
+              expect.objectContaining({
+                canViewProbationDocuments: false,
+              })
+            )
+          })
+        })
+        describe('when prisoner is OUT of prison', () => {
+          beforeEach(() => {
+            // @ts-expect-error ts-migrate(2339)
+            prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+            // @ts-expect-error ts-migrate(2339)
+            oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+            // @ts-expect-error ts-migrate(2339)
+            prisonApi.getDetails.mockReturnValue({
+              ...prisonerDetails,
+              agencyId: 'OUT',
             })
-          )
+          })
+          it('should let the user view probation documents', async () => {
+            const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+
+            expect(getPrisonerProfileData).toEqual(
+              expect.objectContaining({
+                canViewProbationDocuments: false,
+              })
+            )
+          })
         })
       })
 
@@ -498,6 +562,10 @@ describe('prisoner profile service', () => {
         beforeEach(() => {
           // @ts-expect-error ts-migrate(2339) FIXME: Property 'userRoles' does not exist on type '{}'.
           oauthApi.userRoles.mockResolvedValue([{ roleCode: 'POM' }])
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
         })
 
         it('should let the user view probation documents', async () => {

--- a/integration-tests/integration/prisonerProfile/prisonerQuickLook.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerQuickLook.spec.js
@@ -490,42 +490,85 @@ context('Prisoner quick look', () => {
   })
 
   context('When a user has VIEW_PROBATION_DOCUMENTS role', () => {
-    beforeEach(() => {
-      Cypress.Cookies.preserveOnce('hmpps-session-dev')
-      cy.task('stubPrisonerProfileHeaderData', {
-        offenderBasicDetails,
-        offenderFullDetails,
-        iepSummary: {},
-        caseNoteSummary: {},
-        userRoles: [{ roleCode: 'VIEW_PROBATION_DOCUMENTS' }],
-        offenderNo,
+    context('when offender in caseload', () => {
+      beforeEach(() => {
+        Cypress.Cookies.preserveOnce('hmpps-session-dev')
+        cy.task('stubPrisonerProfileHeaderData', {
+          offenderBasicDetails,
+          offenderFullDetails,
+          iepSummary: {},
+          caseNoteSummary: {},
+          userRoles: [{ roleCode: 'VIEW_PROBATION_DOCUMENTS' }],
+          offenderNo,
+        })
+      })
+
+      it('Should show the View documents held by probation link', () => {
+        cy.visit(`/prisoner/${offenderNo}`)
+
+        cy.get('[data-test="probation-documents-link"]').should('contain.text', 'View documents held by probation')
       })
     })
+    context('when offender not in caseload', () => {
+      beforeEach(() => {
+        Cypress.Cookies.preserveOnce('hmpps-session-dev')
+        cy.task('stubPrisonerProfileHeaderData', {
+          offenderBasicDetails: { ...offenderBasicDetails, agencyId: 'LEI' },
+          offenderFullDetails,
+          iepSummary: {},
+          caseNoteSummary: {},
+          userRoles: [{ roleCode: 'VIEW_PROBATION_DOCUMENTS' }],
+          offenderNo,
+        })
+      })
 
-    it('Should show the View documents held by probation link', () => {
-      cy.visit(`/prisoner/${offenderNo}`)
+      it('Should not show the View documents held by probation link', () => {
+        cy.visit(`/prisoner/${offenderNo}`)
 
-      cy.get('[data-test="probation-documents-link"]').should('contain.text', 'View documents held by probation')
+        cy.get('[data-test="probation-documents-link"]').should('not.exist')
+      })
     })
   })
 
   context('When a user has POM role', () => {
-    beforeEach(() => {
-      Cypress.Cookies.preserveOnce('hmpps-session-dev')
-      cy.task('stubPrisonerProfileHeaderData', {
-        offenderBasicDetails,
-        offenderFullDetails,
-        iepSummary: {},
-        caseNoteSummary: {},
-        userRoles: [{ roleCode: 'POM' }],
-        offenderNo,
+    context('when offender not in caseload', () => {
+      beforeEach(() => {
+        Cypress.Cookies.preserveOnce('hmpps-session-dev')
+        cy.task('stubPrisonerProfileHeaderData', {
+          offenderBasicDetails,
+          offenderFullDetails,
+          iepSummary: {},
+          caseNoteSummary: {},
+          userRoles: [{ roleCode: 'POM' }],
+          offenderNo,
+        })
+      })
+
+      it('Should show the View documents held by probation link', () => {
+        cy.visit(`/prisoner/${offenderNo}`)
+
+        cy.get('[data-test="probation-documents-link"]').should('contain.text', 'View documents held by probation')
       })
     })
 
-    it('Should show the View documents held by probation link', () => {
-      cy.visit(`/prisoner/${offenderNo}`)
+    context('when offender not in caseload', () => {
+      beforeEach(() => {
+        Cypress.Cookies.preserveOnce('hmpps-session-dev')
+        cy.task('stubPrisonerProfileHeaderData', {
+          offenderBasicDetails: { ...offenderBasicDetails, agencyId: 'LEI' },
+          offenderFullDetails,
+          iepSummary: {},
+          caseNoteSummary: {},
+          userRoles: [{ roleCode: 'POM' }],
+          offenderNo,
+        })
+      })
 
-      cy.get('[data-test="probation-documents-link"]').should('contain.text', 'View documents held by probation')
+      it('Should not show the View documents held by probation link', () => {
+        cy.visit(`/prisoner/${offenderNo}`)
+
+        cy.get('[data-test="probation-documents-link"]').should('not.exist')
+      })
     })
   })
 

--- a/integration-tests/integration/prisonerProfile/prisonerQuickLook.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerQuickLook.spec.js
@@ -514,7 +514,7 @@ context('Prisoner quick look', () => {
         Cypress.Cookies.preserveOnce('hmpps-session-dev')
         cy.task('stubPrisonerProfileHeaderData', {
           offenderBasicDetails: { ...offenderBasicDetails, agencyId: 'LEI' },
-          offenderFullDetails,
+          offenderFullDetails: { ...offenderFullDetails, agencyId: 'LEI' },
           iepSummary: {},
           caseNoteSummary: {},
           userRoles: [{ roleCode: 'VIEW_PROBATION_DOCUMENTS' }],
@@ -556,7 +556,7 @@ context('Prisoner quick look', () => {
         Cypress.Cookies.preserveOnce('hmpps-session-dev')
         cy.task('stubPrisonerProfileHeaderData', {
           offenderBasicDetails: { ...offenderBasicDetails, agencyId: 'LEI' },
-          offenderFullDetails,
+          offenderFullDetails: { ...offenderFullDetails, agencyId: 'LEI' },
           iepSummary: {},
           caseNoteSummary: {},
           userRoles: [{ roleCode: 'POM' }],


### PR DESCRIPTION
To view probation document you now need to following
1) The correct role - this is unchanged
2) A caseload that matches the prisoner location - this is new

Therefore a POM can no longer view prisoners that have been released or in a another prisoner they don't have a caseload for.

This is a requested change from the MPC team alongside App Support