### PR TITLE
CRS-534 adding calculate release dates button to prisoner profile page.

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -98,6 +98,9 @@ export const apis = {
     ui_url: process.env.USE_OF_FORCE_URL,
     prisons: process.env.USE_OF_FORCE_PRISONS || '',
   },
+  calculateReleaseDates: {
+    ui_url: process.env.CALCULATE_RELEASE_DATES_URL,
+  },
   caseNotes: {
     url: process.env.CASENOTES_API_URL || 'http://localhost:8083',
     timeoutSeconds: toNumber(process.env.API_ENDPOINT_TIMEOUT_SECONDS) || 30,

--- a/backend/services/prisonerProfileService.ts
+++ b/backend/services/prisonerProfileService.ts
@@ -23,6 +23,7 @@ export default ({
 }) => {
   const {
     apis: {
+      calculateReleaseDates: { ui_url: calculateReleaseDatesUrl },
       categorisation: { ui_url: categorisationUrl },
       pathfinder: { ui_url: pathfinderUrl },
       soc: { ui_url: socUrl, enabled: socEnabled },
@@ -159,6 +160,9 @@ export default ({
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'primary_pom' does not exist on ty... Remove this comment to see the full error message
     const pomStaff = allocationManager?.primary_pom && getNamesFromString(allocationManager.primary_pom.name).join(' ')
 
+    const canCalculateReleaseDate =
+      userRoles && (userRoles as any).some((role) => role.roleCode === 'RELEASE_DATES_CALCULATOR')
+
     return {
       activeAlertCount,
       agencyName: assignedLivingUnit.agencyName,
@@ -176,6 +180,7 @@ export default ({
       socProfileUrl: socEnabled && socUrl && socDetails && `${socUrl}nominal/${String((socDetails as any).id)}`,
       showSocReferButton: Boolean(socEnabled && !socDetails && isSocUser),
       socReferUrl: socEnabled && socUrl && `${socUrl}refer/offender/${offenderNo}`,
+      calculateReleaseDatesUrl: `${calculateReleaseDatesUrl}?prisonId=${offenderNo}`,
       categorisationLink: `${categorisationUrl}${bookingId}`,
       categorisationLinkText: (isCatToolUser && 'Manage category') || (offenderInCaseload && 'View category') || '',
       category,
@@ -195,6 +200,7 @@ export default ({
       offenderNo,
       offenderRecordRetained: offenderRetentionRecord && hasLength(offenderRetentionRecord.retentionReasons),
       showAddKeyworkerSession: staffRoles && (staffRoles as any).some((role) => role.role === 'KW'),
+      showCalculateRelseaseDates: offenderInCaseload && canCalculateReleaseDate,
       showReportUseOfForce: useOfForceEnabledPrisons.includes(currentUser.activeCaseLoadId),
       useOfForceUrl: `${useOfForceUrl}/report/${bookingId}/report-use-of-force`,
       userCanEdit: (canViewInactivePrisoner && ['OUT', 'TRN'].includes(agencyId)) || offenderInCaseload,

--- a/backend/services/prisonerProfileService.ts
+++ b/backend/services/prisonerProfileService.ts
@@ -200,7 +200,7 @@ export default ({
       offenderNo,
       offenderRecordRetained: offenderRetentionRecord && hasLength(offenderRetentionRecord.retentionReasons),
       showAddKeyworkerSession: staffRoles && (staffRoles as any).some((role) => role.role === 'KW'),
-      showCalculateRelseaseDates: offenderInCaseload && canCalculateReleaseDate,
+      showCalculateReleaseDates: offenderInCaseload && canCalculateReleaseDate,
       showReportUseOfForce: useOfForceEnabledPrisons.includes(currentUser.activeCaseLoadId),
       useOfForceUrl: `${useOfForceUrl}/report/${bookingId}/report-use-of-force`,
       userCanEdit: (canViewInactivePrisoner && ['OUT', 'TRN'].includes(agencyId)) || offenderInCaseload,

--- a/backend/tests/prisonerProfileService.test.ts
+++ b/backend/tests/prisonerProfileService.test.ts
@@ -255,7 +255,7 @@ describe('prisoner profile service', () => {
         offenderNo: 'ABC123',
         offenderRecordRetained: undefined,
         showAddKeyworkerSession: false,
-        showCalculateRelseaseDates: false,
+        showCalculateReleaseDates: false,
         showReportUseOfForce: false,
         useOfForceUrl: '//useOfForceUrl/report/123/report-use-of-force',
         userCanEdit: false,
@@ -822,7 +822,7 @@ describe('prisoner profile service', () => {
 
           expect(getPrisonerProfileData).toEqual(
             expect.objectContaining({
-              showCalculateRelseaseDates: true,
+              showCalculateReleaseDates: true,
               calculateReleaseDatesUrl: 'http://crd-ui/?prisonId=ABC123',
             })
           )
@@ -840,7 +840,7 @@ describe('prisoner profile service', () => {
 
           expect(getPrisonerProfileData).toEqual(
             expect.objectContaining({
-              showCalculateRelseaseDates: false,
+              showCalculateReleaseDates: false,
             })
           )
         })
@@ -859,7 +859,7 @@ describe('prisoner profile service', () => {
 
           expect(getPrisonerProfileData).toEqual(
             expect.objectContaining({
-              showCalculateRelseaseDates: false,
+              showCalculateReleaseDates: false,
             })
           )
         })

--- a/backend/tests/prisonerProfileService.test.ts
+++ b/backend/tests/prisonerProfileService.test.ts
@@ -14,6 +14,10 @@ config.apis.soc = {
   enabled: true,
 }
 
+config.apis.calculateReleaseDates = {
+  ui_url: 'http://crd-ui/',
+}
+
 describe('prisoner profile service', () => {
   const context = {}
   const prisonApi = {}
@@ -237,6 +241,7 @@ describe('prisoner profile service', () => {
         age: undefined,
         dateOfBirth: undefined,
         birthPlace: undefined,
+        calculateReleaseDatesUrl: 'http://crd-ui/?prisonId=ABC123',
         category: 'Cat C',
         csra: 'High',
         csraReviewDate: '23/11/2016',
@@ -250,6 +255,7 @@ describe('prisoner profile service', () => {
         offenderNo: 'ABC123',
         offenderRecordRetained: undefined,
         showAddKeyworkerSession: false,
+        showCalculateRelseaseDates: false,
         showReportUseOfForce: false,
         useOfForceUrl: '//useOfForceUrl/report/123/report-use-of-force',
         userCanEdit: false,
@@ -796,6 +802,67 @@ describe('prisoner profile service', () => {
         const profileData = await service.getPrisonerProfileData(context, offenderNo)
 
         expect(profileData.location).toBe('No cell allocated')
+      })
+    })
+    describe('when the user has the RELEASE_DATES_CALCULATOR role', () => {
+      beforeEach(() => {
+        // @ts-expect-error ts-migrate(2339) FIXME: Property 'userRoles' does not exist on type '{}'.
+        oauthApi.userRoles.mockResolvedValue([{ roleCode: 'RELEASE_DATES_CALCULATOR' }])
+      })
+
+      describe('when prisoner is in active caseload', () => {
+        beforeEach(() => {
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+        })
+        it('should show the user the calculate release dates button', async () => {
+          const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+
+          expect(getPrisonerProfileData).toEqual(
+            expect.objectContaining({
+              showCalculateRelseaseDates: true,
+              calculateReleaseDatesUrl: 'http://crd-ui/?prisonId=ABC123',
+            })
+          )
+        })
+      })
+      describe('when prisoner is not in active caseload', () => {
+        beforeEach(() => {
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+        })
+        it('should not show the user the calculate release dates button', async () => {
+          const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+
+          expect(getPrisonerProfileData).toEqual(
+            expect.objectContaining({
+              showCalculateRelseaseDates: false,
+            })
+          )
+        })
+      })
+    })
+    describe('when the user does not have the RELEASE_DATES_CALCULATOR role', () => {
+      describe('when prisoner is in active caseload', () => {
+        beforeEach(() => {
+          // @ts-expect-error ts-migrate(2339)
+          prisonApi.userCaseLoads.mockResolvedValue([{ caseLoadId: 'MDI' }, { caseLoadId: 'LEI' }])
+          // @ts-expect-error ts-migrate(2339)
+          oauthApi.currentUser.mockReturnValue({ staffId: 111, activeCaseLoadId: 'MDI' })
+        })
+        it('should not show the user the calculate release dates button', async () => {
+          const getPrisonerProfileData = await service.getPrisonerProfileData(context, offenderNo)
+
+          expect(getPrisonerProfileData).toEqual(
+            expect.objectContaining({
+              showCalculateRelseaseDates: false,
+            })
+          )
+        })
       })
     })
   })

--- a/helm_deploy/digital-prison-services/templates/_envs.tpl
+++ b/helm_deploy/digital-prison-services/templates/_envs.tpl
@@ -139,20 +139,20 @@ env:
   - name: API_WHEREABOUTS_ENDPOINT_URL
     value: {{ .Values.env.API_WHEREABOUTS_ENDPOINT_URL | quote }}
 
-  {{- if .Values.env.SYSTEM_PHASE }}
+{{- if .Values.env.SYSTEM_PHASE }}
   - name: SYSTEM_PHASE
     value: {{ .Values.env.SYSTEM_PHASE | quote }}
-  {{- end }}
+{{- end }}
 
-  {{- if .Values.env.API_DATA_COMPLIANCE_ENDPOINT_URL }}
+{{- if .Values.env.API_DATA_COMPLIANCE_ENDPOINT_URL }}
   - name: API_DATA_COMPLIANCE_ENDPOINT_URL
     value: {{ .Values.env.API_DATA_COMPLIANCE_ENDPOINT_URL | quote }}
-  {{- end }}
+{{- end }}
 
-  {{- if .Values.env.DISPLAY_RETENTION_LINK }}
+{{- if .Values.env.DISPLAY_RETENTION_LINK }}
   - name: DISPLAY_RETENTION_LINK
     value: {{ .Values.env.DISPLAY_RETENTION_LINK | quote }}
-  {{- end }}
+{{- end }}
 
   - name: UPDATE_ATTENDANCE_PRISONS
     value: {{ .Values.env.UPDATE_ATTENDANCE_PRISONS | quote }}
@@ -261,5 +261,8 @@ env:
 
   - name: PVB_URL
     value: {{ .Values.env.PVB_URL | quote }}
+
+  - name: CALCULATE_RELEASE_DATES_URL
+    value: {{ .Values.env.CALCULATE_RELEASE_DATES_URL | quote }}
 
 {{- end -}}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -62,5 +62,5 @@ env:
   PRISONS_WITH_MANAGE_ADJUDICATIONS_ENABLED: ""
   MANAGE_ADJUDICAIONS_URL: https://manage-adjudications-dev.hmpps.service.justice.gov.uk/
   PVB_URL: https://manage-a-prison-visit-dev.hmpps.service.justice.gov.uk/
-  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-dev.hmpps.service.justice.gov.uk/
+  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-dev.hmpps.service.justice.gov.uk
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -62,4 +62,5 @@ env:
   PRISONS_WITH_MANAGE_ADJUDICATIONS_ENABLED: ""
   MANAGE_ADJUDICAIONS_URL: https://manage-adjudications-dev.hmpps.service.justice.gov.uk/
   PVB_URL: https://manage-a-prison-visit-dev.hmpps.service.justice.gov.uk/
+  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-dev.hmpps.service.justice.gov.uk/
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -62,7 +62,7 @@ env:
   CURIOUS_URL: https://testservices.sequation.net/sequation-virtual-campus2-api/
   DISABLE_REQUEST_LIMITER: true
   PVB_URL: https://manage-a-prison-visit-preprod.hmpps.service.justice.gov.uk/
-  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-preprod.hmpps.service.justice.gov.uk/
+  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-preprod.hmpps.service.justice.gov.uk
 
 allowlist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -62,6 +62,7 @@ env:
   CURIOUS_URL: https://testservices.sequation.net/sequation-virtual-campus2-api/
   DISABLE_REQUEST_LIMITER: true
   PVB_URL: https://manage-a-prison-visit-preprod.hmpps.service.justice.gov.uk/
+  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-preprod.hmpps.service.justice.gov.uk/
 
 allowlist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -60,7 +60,7 @@ env:
   CURIOUS_URL: https://liveservices.sequation.com/sequation-virtual-campus2-api/
   DISABLE_REQUEST_LIMITER: true
   PVB_URL: https://manage-a-prison-visit.hmpps.service.justice.gov.uk/
-  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates.hmpps.service.justice.gov.uk/
+  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates.hmpps.service.justice.gov.uk
 
 allowlist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -60,7 +60,7 @@ env:
   CURIOUS_URL: https://liveservices.sequation.com/sequation-virtual-campus2-api/
   DISABLE_REQUEST_LIMITER: true
   PVB_URL: https://manage-a-prison-visit.hmpps.service.justice.gov.uk/
-
+  CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates.hmpps.service.justice.gov.uk/
 
 allowlist:
   office: "217.33.148.210/32"

--- a/views/prisonerProfile/partials/prisonerProfileHeader.njk
+++ b/views/prisonerProfile/partials/prisonerProfileHeader.njk
@@ -7,61 +7,61 @@
         <strong>{{ label }}</strong>
         <br>
         <span data-test="{{ dataTest }}">
-             {{ content | showDefault(missingValue or 'Not entered') | safe }}
-      </span>
+            {{ content | showDefault(missingValue or 'Not entered') | safe }}
+        </span>
     </li>
 {% endmacro %}
 
 {% set alertNumbersHtml %}
-    <span>{{ prisonerProfileData.activeAlertCount }} active, {{ prisonerProfileData.inactiveAlertCount }} inactive</span>
-    <br>
-    <a data-test="view-alerts-link" class="govuk-link"
+<span>{{ prisonerProfileData.activeAlertCount }} active, {{ prisonerProfileData.inactiveAlertCount }} inactive</span>
+<br>
+<a data-test="view-alerts-link" class="govuk-link"
        href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/alerts' }}">
         View alerts
     </a>
 {% endset %}
 
 {% set incentiveLevelHtml %}
-    <span>{{ prisonerProfileData.incentiveLevel | showDefault('Not entered') }}</span>
-    {% if prisonerProfileData.userCanEdit %}
-        <br>
-        <a data-test="iep-details-link" class="govuk-link"
+<span>{{ prisonerProfileData.incentiveLevel | showDefault('Not entered') }}</span>
+{% if prisonerProfileData.userCanEdit %}
+    <br>
+    <a data-test="iep-details-link" class="govuk-link"
            href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/incentive-level-details' }}">
             View details <span class="govuk-visually-hidden">for Incentive Level</span>
-        </a>
-    {% endif %}
+    </a>
+{% endif %}
 {% endset %}
 
 {% set categoryHtml %}
-    {{ categoryFlag(prisonerProfileData.category, prisonerProfileData.categoryCode) }}
+{{ categoryFlag(prisonerProfileData.category, prisonerProfileData.categoryCode) }}
 
-    {% if prisonerProfileData.categorisationLinkText %}
-        <br>
-        <a data-qa="categorisation-external-link" class="govuk-link"
+{% if prisonerProfileData.categorisationLinkText %}
+    <br>
+    <a data-qa="categorisation-external-link" class="govuk-link"
            href="{{ prisonerProfileData.categorisationLink }}">
-            {{ prisonerProfileData.categorisationLinkText }}
-        </a>
-    {% endif %}
+        {{ prisonerProfileData.categorisationLinkText }}
+    </a>
+{% endif %}
 {% endset %}
 
 {% set locationHtml %}
-    {{ prisonerProfileData.location }}
-    <br>
-    {{ prisonerProfileData.agencyName }}
-    <br>
-    <a data-qa="cell-history-link" class="govuk-link"
+{{ prisonerProfileData.location }}
+<br>
+{{ prisonerProfileData.agencyName }}
+<br>
+<a data-qa="cell-history-link" class="govuk-link"
        href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/cell-history' }}">
         View details
     </a>
 {% endset %}
 
 {% set csraHtml %}
-    <span data-test="csra-details">{{ prisonerProfileData.csra }} - {{ prisonerProfileData.csraReviewDate or 'No previous review' }}</span>
-    <br>
-    <a data-test="csra-link" class="govuk-link"
+<span data-test="csra-details">{{ prisonerProfileData.csra }} - {{ prisonerProfileData.csraReviewDate or 'No previous review' }}</span>
+<br>
+<a data-test="csra-link" class="govuk-link"
        href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/csra-history' }}">
         View details <span class="govuk-visually-hidden">of CSRA</span>
-    </a>
+</a>
 {% endset %}
 
 <div class="header-with-link">
@@ -83,7 +83,7 @@
     <div class="prisoner-header__image-container">
         <a href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/image' }}">
             <img src="{{ '/app/images/' + prisonerProfileData.offenderNo + '/data' }}"
-                 alt="{{ 'Picture of ' + prisonerProfileData.offenderName }}" class="prisoner-image" />
+                 alt="{{ 'Picture of ' + prisonerProfileData.offenderName }}" class="prisoner-image"/>
         </a>
     </div>
 
@@ -112,6 +112,15 @@
         </ul>
 
         <div class="prisoner-header__details__actions">
+            {% if prisonerProfileData.showCalculateRelseaseDates %}
+                {{ govukButton({
+                    text: "Calculate release dates",
+                    element: "a",
+                    classes: "govuk-button--link govuk-!-margin-bottom-3",
+                    href: prisonerProfileData.calculateReleaseDatesUrl
+                }) }}
+            {% endif %}
+
             {% if prisonerProfileData.showPathfinderReferButton %}
                 <a href="{{ prisonerProfileData.pathfinderReferUrl }}"
                    class="govuk-button govuk-button--link govuk-!-margin-bottom-3" data-module="govuk-button"

--- a/views/prisonerProfile/partials/prisonerProfileHeader.njk
+++ b/views/prisonerProfile/partials/prisonerProfileHeader.njk
@@ -112,7 +112,7 @@
         </ul>
 
         <div class="prisoner-header__details__actions">
-            {% if prisonerProfileData.showCalculateRelseaseDates %}
+            {% if prisonerProfileData.showCalculateReleaseDates %}
                 {{ govukButton({
                     text: "Calculate release dates",
                     element: "a",


### PR DESCRIPTION
Adding a calculate release dates button to the prisoner profile page.

We're in the middle of creating our pre prod environment now. There is a sub task to check the url in the dps helm config when we have the service running, we will do the same thing with production

The button won't appear on preprod or prod because no one has the calc role currently. We will use the role to act as a feature toggle.