### PR TITLE
Add a new DPS tile for the Legacy PVB

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -170,6 +170,9 @@ export const apis = {
   managePrisonVisits: {
     ui_url: process.env.MANAGE_PRISON_VISITS_URL || '',
   },
+  legacyPrisonVisits: {
+    ui_url: process.env.LEGACY_PRISON_VISITS_URL || '',
+  },
   createAndVaryALicence: {
     url: process.env.CREATE_AND_VARY_A_LICENCE_URL,
     enabled_prisons: process.env.CREATE_AND_VARY_A_LICENCE_ENABLED_PRISONS || '',

--- a/backend/controllers/homepage/homepage.ts
+++ b/backend/controllers/homepage/homepage.ts
@@ -13,6 +13,7 @@ const {
     pinPhones,
     manageAdjudications,
     managePrisonVisits,
+    legacyPrisonVisits,
     welcomePeopleIntoPrison,
     manageRestrictedPatients,
     incentives,
@@ -190,6 +191,13 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig, key
       description: 'Book, view and cancel a prisoner’s social visits.',
       href: managePrisonVisits.ui_url,
       enabled: () => managePrisonVisits.ui_url && userHasRoles(['MANAGE_PRISON_VISITS']),
+    },
+    {
+      id: 'legacy-prison-visit',
+      heading: 'Manage prison visits',
+      description: 'Book, view and cancel a prisoner’s social visits.',
+      href: legacyPrisonVisits.ui_url,
+      enabled: () => legacyPrisonVisits.ui_url && userHasRoles(['PVB_REQUESTS']),
     },
     {
       id: 'check-rule39-mail',

--- a/backend/tests/homepageController.test.ts
+++ b/backend/tests/homepageController.test.ts
@@ -21,6 +21,7 @@ describe('Homepage', () => {
     config.apis.manageAdjudications.ui_url = undefined
     config.apis.manageRestrictedPatients.ui_url = undefined
     config.apis.managePrisonVisits.ui_url = undefined
+    config.apis.legacyPrisonVisits.ui_url = undefined
     config.applications.sendLegalMail.url = undefined
     config.apis.welcomePeopleIntoPrison.enabled_prisons = undefined
     config.apis.welcomePeopleIntoPrison.url = undefined
@@ -225,6 +226,27 @@ describe('Homepage', () => {
             expect.objectContaining({
               id: 'book-a-prison-visit',
               href: 'http://book-a-prison-visit-url',
+              heading: 'Manage prison visits',
+              description: 'Book, view and cancel a prisoner’s social visits.',
+            }),
+          ],
+        })
+      )
+    })
+
+    it('should render home page with the legacy book a prison visit task', async () => {
+      oauthApi.userRoles.mockResolvedValue([{ roleCode: 'PVB_REQUESTS' }])
+      config.apis.legacyPrisonVisits.ui_url = 'http://legacy-prison-visit-url'
+
+      await controller(req, res)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'homepage/homepage.njk',
+        expect.objectContaining({
+          tasks: [
+            expect.objectContaining({
+              id: 'legacy-prison-visit',
+              href: 'http://legacy-prison-visit-url',
               heading: 'Manage prison visits',
               description: 'Book, view and cancel a prisoner’s social visits.',
             }),

--- a/helm_deploy/digital-prison-services/templates/_envs.tpl
+++ b/helm_deploy/digital-prison-services/templates/_envs.tpl
@@ -280,6 +280,9 @@ env:
   - name: MANAGE_PRISON_VISITS_URL
     value: {{ .Values.env.MANAGE_PRISON_VISITS_URL | quote }}
 
+  - name:  LEGACY_PRISON_VISITS_URL
+    value: {{ .Values.env.LEGACY_PRISON_VISITS_URL | quote }}
+
   - name: CALCULATE_RELEASE_DATES_URL
     value: {{ .Values.env.CALCULATE_RELEASE_DATES_URL | quote }}
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -40,7 +40,7 @@ env:
   TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
   CASENOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk/
-  ALLOCATION_MANAGER_ENDPOINT_URL: https://dev.moic.service.justice.gov.uk/ 
+  ALLOCATION_MANAGER_ENDPOINT_URL: https://dev.moic.service.justice.gov.uk/
   PATHFINDER_UI_URL: https://dev.pathfinder.service.justice.gov.uk/
   PATHFINDER_ENDPOINT_API_URL: https://dev-api.pathfinder.service.justice.gov.uk/
   PIN_PHONES_URL: https://pcms-dev.prison.service.justice.gov.uk/
@@ -56,7 +56,7 @@ env:
   CURIOUS_URL: https://testservices.sequation.net/sequation-virtual-campus2-api/
   SYSTEM_PHASE: DEV
   BVL_URL: https://book-video-link-dev.prison.service.justice.gov.uk
-  MOIC_URL: https://dev.moic.service.justice.gov.uk 
+  MOIC_URL: https://dev.moic.service.justice.gov.uk
   OMIC_URL: https://dev.manage-key-workers.service.justice.gov.uk
   MANAGE_AUTH_ACCOUNTS_URL: https://manage-users-dev.hmpps.service.justice.gov.uk
   PECS_URL: https://hmpps-book-secure-move-frontend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
@@ -66,6 +66,7 @@ env:
   MANAGE_ADJUDICATIONS_URL: https://manage-adjudications-dev.hmpps.service.justice.gov.uk/
   MANAGE_RESTRICTED_PATIENTS_URL: https://manage-restricted-patients-dev.hmpps.service.justice.gov.uk/
   MANAGE_PRISON_VISITS_URL: https://manage-prison-visits-dev.prison.service.justice.gov.uk/
+  LEGACY_PRISON_VISITS_URL: https://prison-visits-booking-staff-dev.apps.live.cloud-platform.service.justice.gov.uk/
   CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-dev.hmpps.service.justice.gov.uk
   SEND_LEGAL_MAIL_URL: https://check-rule39-mail-dev.prison.service.justice.gov.uk
   WELCOME_PEOPLE_INTO_PRISON_URL: https://welcome-dev.prison.service.justice.gov.uk/
@@ -73,4 +74,3 @@ env:
   CREATE_AND_VARY_A_LICENCE_URL: https://create-and-vary-a-licence-dev.hmpps.service.justice.gov.uk/
   CREATE_AND_VARY_A_LICENCE_ENABLED_PRISONS: "MDI,LEI,LPI,BMI,PVI,BXI,WAI"
   RESTRICTED_PATIENT_API_URL: https://restricted-patients-api-dev.hmpps.service.justice.gov.uk/
-  

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -66,6 +66,7 @@ env:
   CURIOUS_URL: https://preprodservices.sequation.net/sequation-virtual-campus2-api/
   DISABLE_REQUEST_LIMITER: true
   MANAGE_PRISON_VISITS_URL: https://manage-prison-visits-preprod.prison.service.justice.gov.uk/
+  LEGACY_PRISON_VISITS_URL: https://prison-visits-booking-staff-staging.apps.live.cloud-platform.service.justice.gov.uk/
   CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates-preprod.hmpps.service.justice.gov.uk
   SEND_LEGAL_MAIL_URL: https://check-rule39-mail-preprod.prison.service.justice.gov.uk
   WELCOME_PEOPLE_INTO_PRISON_URL: https://welcome-preprod.prison.service.justice.gov.uk/

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -64,6 +64,7 @@ env:
   CURIOUS_URL: https://liveservices.sequation.com/sequation-virtual-campus2-api/
   DISABLE_REQUEST_LIMITER: true
   MANAGE_PRISON_VISITS_URL: https://manage-prison-visits.prison.service.justice.gov.uk/
+  LEGACY_PRISON_VISITS_URL: https://staff.prisonvisits.service.justice.gov.uk/
   CALCULATE_RELEASE_DATES_URL: https://calculate-release-dates.hmpps.service.justice.gov.uk
   SEND_LEGAL_MAIL_URL: https://check-rule39-mail.prison.service.justice.gov.uk
   WELCOME_PEOPLE_INTO_PRISON_URL: https://welcome.prison.service.justice.gov.uk/


### PR DESCRIPTION
The legacy PVB is being re-animated for a short period of time whilst
its replacement is completed.  Previously PVB was only ever accessed via
its own service URL and therefore has never been used with DPS.

This PR adds a tile specifically for the legacy service so that we can
encourage users to access it via the preferred method.

Should resolve https://dsdmoj.atlassian.net/browse/VB-879