### PR TITLE
SDI-213: ♻️  Switch to new prisoners unaccounted for endpoint

### DIFF
--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -274,9 +274,6 @@ export const prisonApiFactory = (client) => {
   const addSingleAppointment = (context, bookingId, body) =>
     post(context, `/api/bookings/${bookingId}/appointments`, body)
 
-  const getOffenderActivities = (context, { agencyId, date, period }) =>
-    get(context, `/api/schedules/${agencyId}/activities?date=${date}&timeSlot=${period}`)
-
   const getOffenderActivitiesOverDateRange = (context, { agencyId, fromDate, toDate, period }) =>
     get(
       context,
@@ -496,7 +493,6 @@ export const prisonApiFactory = (client) => {
     getAdjudicationDetails,
     getAdjudicationsForBooking,
     addAppointments,
-    getOffenderActivities,
     getAlertTypes,
     createAlert,
     getAlert,

--- a/backend/api/whereaboutsApi.ts
+++ b/backend/api/whereaboutsApi.ts
@@ -37,8 +37,10 @@ export const whereaboutsApiFactory = (client) => {
 
   const getAbsenceReasons = (context) => get(context, '/absence-reasons')
 
-  const getPrisonAttendance = (context, { agencyId, date, period }) =>
-    get(context, `/attendances/${agencyId}/attendance-for-scheduled-activities?date=${date}&period=${period}`)
+  const prisonersUnaccountedFor = (context, { agencyId, date, period }) =>
+    getWithCustomTimeout(context, `/attendances/${agencyId}/unaccounted-for?date=${date}&period=${period}`, {
+      customTimeout: 30000,
+    })
 
   const postAttendances = (context, body) => post(context, '/attendances', body)
 
@@ -128,7 +130,7 @@ export const whereaboutsApiFactory = (client) => {
     postAttendance,
     putAttendance,
     getAbsenceReasons,
-    getPrisonAttendance,
+    prisonersUnaccountedFor,
     postAttendances,
     getAttendanceStats,
     getAbsences,

--- a/backend/controllers/attendance/offenderActivities.ts
+++ b/backend/controllers/attendance/offenderActivities.ts
@@ -8,7 +8,8 @@ export const offenderActivitesFactory = (prisonApi, whereaboutsApi) => {
       date,
       period: timeSlot,
     }
-    const prisonersUnaccountedFor = await whereaboutsApi.prisonersUnaccountedFor(context, params)
+
+    const { scheduled: prisonersUnaccountedFor } = await whereaboutsApi.prisonersUnaccountedFor(context, params)
     const offenderNumbers = prisonersUnaccountedFor.map((prisoner) => prisoner.offenderNo)
 
     const searchCriteria = { agencyId, date, timeSlot, offenderNumbers }

--- a/backend/controllers/attendance/offenderActivities.ts
+++ b/backend/controllers/attendance/offenderActivities.ts
@@ -8,21 +8,7 @@ export const offenderActivitesFactory = (prisonApi, whereaboutsApi) => {
       date,
       period: timeSlot,
     }
-
-    const [offenderActivities, prisonAttendance] = await Promise.all([
-      prisonApi.getOffenderActivities(context, params),
-      whereaboutsApi.getPrisonAttendance(context, params),
-    ])
-
-    const prisonersUnaccountedFor = offenderActivities.filter(
-      (offenderActivity) =>
-        !prisonAttendance.attendances ||
-        !prisonAttendance.attendances.find(
-          (attendance) =>
-            offenderActivity.bookingId === attendance.bookingId && offenderActivity.eventId === attendance.eventId
-        )
-    )
-
+    const prisonersUnaccountedFor = await whereaboutsApi.prisonersUnaccountedFor(context, params)
     const offenderNumbers = prisonersUnaccountedFor.map((prisoner) => prisoner.offenderNo)
 
     const searchCriteria = { agencyId, date, timeSlot, offenderNumbers }
@@ -32,12 +18,10 @@ export const offenderActivitesFactory = (prisonApi, whereaboutsApi) => {
       prisonApi.getAppointments(context, searchCriteria),
     ])
 
-    const prisonersWithOtherEvents = prisonersUnaccountedFor.map((prisoner) => ({
+    return prisonersUnaccountedFor.map((prisoner) => ({
       ...prisoner,
       eventsElsewhere: [...visits, ...appointments].filter((event) => prisoner.offenderNo === event.offenderNo),
     }))
-
-    return prisonersWithOtherEvents
   }
 
   return { getPrisonersUnaccountedFor }

--- a/backend/tests/offenderActivities.test.ts
+++ b/backend/tests/offenderActivities.test.ts
@@ -79,7 +79,7 @@ describe('offender activities', () => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getAppointments' does not exist on type ... Remove this comment to see the full error message
       prisonApi.getAppointments = jest.fn().mockReturnValue([])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'prisonersUnaccountedFor' does not exist on t... Remove this comment to see the full error message
-      whereaboutsApi.prisonersUnaccountedFor = jest.fn().mockReturnValue(scheduledActivitiesResponse)
+      whereaboutsApi.prisonersUnaccountedFor = jest.fn().mockReturnValue({ scheduled: scheduledActivitiesResponse })
     })
 
     it('should return the correct number of separate offender activities when there are is no matching attendance record', async () => {
@@ -122,7 +122,7 @@ describe('offender activities', () => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'prisonersUnaccountedFor' does not exist on t... Remove this comment to see the full error message
       whereaboutsApi.prisonersUnaccountedFor = jest
         .fn()
-        .mockReturnValue(scheduledActivitiesResponse.filter((r) => r.eventId !== 378088468))
+        .mockReturnValue({ scheduled: scheduledActivitiesResponse.filter((r) => r.eventId !== 378088468) })
 
       const response = await getPrisonersUnaccountedFor(context, 'LEI', '2019-08-07', 'PM')
 

--- a/backend/tests/offenderActivities.test.ts
+++ b/backend/tests/offenderActivities.test.ts
@@ -74,14 +74,12 @@ const scheduledActivitiesResponse = [
 describe('offender activities', () => {
   describe('getPrisonersUnaccountedFor()', () => {
     beforeEach(() => {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'getOffenderActivities' does not exist on... Remove this comment to see the full error message
-      prisonApi.getOffenderActivities = jest.fn().mockReturnValue(scheduledActivitiesResponse)
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getVisits' does not exist on type '{}'.
       prisonApi.getVisits = jest.fn().mockReturnValue([])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getAppointments' does not exist on type ... Remove this comment to see the full error message
       prisonApi.getAppointments = jest.fn().mockReturnValue([])
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'getPrisonAttendance' does not exist on t... Remove this comment to see the full error message
-      whereaboutsApi.getPrisonAttendance = jest.fn().mockReturnValue({ attendances: [] })
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'prisonersUnaccountedFor' does not exist on t... Remove this comment to see the full error message
+      whereaboutsApi.prisonersUnaccountedFor = jest.fn().mockReturnValue(scheduledActivitiesResponse)
     })
 
     it('should return the correct number of separate offender activities when there are is no matching attendance record', async () => {
@@ -91,105 +89,7 @@ describe('offender activities', () => {
       expect(response).toEqual(scheduledActivitiesResponse.map((activity) => ({ ...activity, eventsElsewhere: [] })))
     })
 
-    it('should only return unaccounted for offender activities', async () => {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'getPrisonAttendance' does not exist on t... Remove this comment to see the full error message
-      whereaboutsApi.getPrisonAttendance.mockReturnValueOnce({
-        attendances: [
-          {
-            id: 4896,
-            bookingId: 1044681,
-            eventId: 378088468,
-            eventLocationId: 721763,
-            period: 'PM',
-            prisonId: 'MDI',
-            attended: true,
-            paid: true,
-            eventDate: '2019-08-07',
-            createDateTime: '2019-08-07T10:06:13.58809',
-            createUserId: 'RCOOPER_ADM',
-            modifyDateTime: '2019-08-07T10:06:13.58809',
-            modifyUserId: 'RCOOPER_ADM',
-            locked: false,
-          },
-        ],
-      })
-
-      const response = await getPrisonersUnaccountedFor(context, 'LEI', '2019-08-07', 'PM')
-
-      expect(response).toEqual([
-        {
-          bookingId: 1044681,
-          cellLocation: 'MDI-6-1-026',
-          comment: 'Recovery PE 15.00pm',
-          endTime: '2019-08-07T16:30:00',
-          event: 'PA',
-          eventDescription: 'Prison Activities',
-          eventId: 378065320,
-          eventsElsewhere: [],
-          firstName: 'ETIENNE',
-          lastName: 'DELEWSKI',
-          locationId: 200532,
-          offenderNo: 'G7178GP',
-          paid: false,
-          startTime: '2019-08-07T15:00:00',
-        },
-        {
-          bookingId: 1044681,
-          cellLocation: 'MDI-6-1-026',
-          comment: 'Recovery PE 16.30pm',
-          endTime: '2019-08-07T17:30:00',
-          event: 'PA',
-          eventDescription: 'Prison Activities',
-          eventId: 378065321,
-          eventsElsewhere: [],
-          firstName: 'ETIENNE',
-          lastName: 'DELEWSKI',
-          locationId: 200533,
-          offenderNo: 'G7178GP',
-          paid: false,
-          startTime: '2019-08-07T16:30:00',
-        },
-        {
-          bookingId: 1044680,
-          cellLocation: 'MDI-6-1-027',
-          comment: 'Recovery PE 15.30pm',
-          endTime: '2019-08-07T17:30:00',
-          event: 'PA',
-          eventDescription: 'Prison Activities',
-          eventId: 378065322,
-          eventsElsewhere: [],
-          firstName: 'TEST',
-          lastName: 'USER',
-          locationId: 200535,
-          offenderNo: 'G7179GP',
-          paid: false,
-          startTime: '2019-08-07T15:30:00',
-        },
-      ])
-    })
-
-    it('should return activites populated with events and appointments', async () => {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'getPrisonAttendance' does not exist on t... Remove this comment to see the full error message
-      whereaboutsApi.getPrisonAttendance.mockReturnValueOnce({
-        attendances: [
-          {
-            id: 4896,
-            bookingId: 1044681,
-            eventId: 378088468,
-            eventLocationId: 721763,
-            period: 'PM',
-            prisonId: 'MDI',
-            attended: true,
-            paid: true,
-            eventDate: '2019-08-07',
-            createDateTime: '2019-08-07T10:06:13.58809',
-            createUserId: 'RCOOPER_ADM',
-            modifyDateTime: '2019-08-07T10:06:13.58809',
-            modifyUserId: 'RCOOPER_ADM',
-            locked: false,
-          },
-        ],
-      })
+    it('should return activities populated with events and appointments', async () => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getVisits' does not exist on type '{}'.
       prisonApi.getVisits = jest.fn().mockReturnValueOnce([
         {
@@ -219,6 +119,10 @@ describe('offender activities', () => {
           startTime: '2019-08-07T16:00:00',
         },
       ])
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'prisonersUnaccountedFor' does not exist on t... Remove this comment to see the full error message
+      whereaboutsApi.prisonersUnaccountedFor = jest
+        .fn()
+        .mockReturnValue(scheduledActivitiesResponse.filter((r) => r.eventId !== 378088468))
 
       const response = await getPrisonersUnaccountedFor(context, 'LEI', '2019-08-07', 'PM')
 

--- a/integration-tests/integration/prisonersUnaccountedFor.spec.js
+++ b/integration-tests/integration/prisonersUnaccountedFor.spec.js
@@ -55,30 +55,32 @@ context('Prisoners unaccounted for', () => {
 
     const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DD')
 
-    cy.task('stubPrisonersUnaccountedFor', [
-      {
-        eventId: 1,
-        bookingId: -1,
-        offenderNo: offenderNo1,
-        firstName: 'Bob',
-        lastName: 'Doe',
-        cellLocation: 'MDI-1-1',
-        startTime: `${yesterday}T10:00:00`,
-        eventType: 'PA',
-        comment: 'Wing cleaner 1',
-      },
-      {
-        eventId: 2,
-        bookingId: -2,
-        offenderNo: offenderNo2,
-        firstName: 'Dave',
-        lastName: 'Doe',
-        cellLocation: 'MDI-1-2',
-        startTime: `${yesterday}T10:10:00`,
-        eventType: 'PA',
-        comment: 'Wing cleaner 2',
-      },
-    ])
+    cy.task('stubPrisonersUnaccountedFor', {
+      scheduled: [
+        {
+          eventId: 1,
+          bookingId: -1,
+          offenderNo: offenderNo1,
+          firstName: 'Bob',
+          lastName: 'Doe',
+          cellLocation: 'MDI-1-1',
+          startTime: `${yesterday}T10:00:00`,
+          eventType: 'PA',
+          comment: 'Wing cleaner 1',
+        },
+        {
+          eventId: 2,
+          bookingId: -2,
+          offenderNo: offenderNo2,
+          firstName: 'Dave',
+          lastName: 'Doe',
+          cellLocation: 'MDI-1-2',
+          startTime: `${yesterday}T10:10:00`,
+          eventType: 'PA',
+          comment: 'Wing cleaner 2',
+        },
+      ],
+    })
     cy.task('stubVisits', [
       {
         offenderNo: offenderNo1,

--- a/integration-tests/integration/prisonersUnaccountedFor.spec.js
+++ b/integration-tests/integration/prisonersUnaccountedFor.spec.js
@@ -55,7 +55,7 @@ context('Prisoners unaccounted for', () => {
 
     const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DD')
 
-    cy.task('stubOffenderActivities', [
+    cy.task('stubPrisonersUnaccountedFor', [
       {
         eventId: 1,
         bookingId: -1,
@@ -79,7 +79,6 @@ context('Prisoners unaccounted for', () => {
         comment: 'Wing cleaner 2',
       },
     ])
-    cy.task('stubAttendanceForScheduledActivities', { attendances: [] })
     cy.task('stubVisits', [
       {
         offenderNo: offenderNo1,

--- a/integration-tests/mockApis/prisonApi.js
+++ b/integration-tests/mockApis/prisonApi.js
@@ -148,20 +148,6 @@ module.exports = {
         jsonBody: suspensions,
       },
     }),
-  stubOffenderActivities: (activities) =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: '/api/schedules/[A-Z].+?/activities.+?',
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: activities || [],
-      },
-    }),
   stubProgEventsAtLocation: (locationId, timeSlot, date, activities, suspended = true) => {
     const dateAndTimeSlotParameters = date ? `${timeSlot ? `timeSlot=${timeSlot}&` : ''}date=${date}` : '.+?'
 

--- a/integration-tests/mockApis/whereabouts.js
+++ b/integration-tests/mockApis/whereabouts.js
@@ -402,10 +402,13 @@ module.exports = {
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/whereabouts/attendances/[A-Z].+?/unaccounted-for.+?',
+        urlPattern: '/whereabouts/attendances/[A-Z].+?/unaccounted-for.*',
       },
       response: {
         status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
         jsonBody: scheduledActivities || {},
       },
     }),

--- a/integration-tests/mockApis/whereabouts.js
+++ b/integration-tests/mockApis/whereabouts.js
@@ -398,15 +398,15 @@ module.exports = {
         jsonBody: cellMoveReasonResponse,
       },
     }),
-  stubAttendanceForScheduledActivities: (attendances) =>
+  stubPrisonersUnaccountedFor: (scheduledActivities) =>
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/whereabouts/attendances/[A-Z].+?/attendance-for-scheduled-activities.+?',
+        urlPattern: '/whereabouts/attendances/[A-Z].+?/unaccounted-for.+?',
       },
       response: {
         status: 200,
-        jsonBody: attendances || {},
+        jsonBody: scheduledActivities || {},
       },
     }),
   stubAttendanceForBookings: (agencyId, fromDate, toDate, period, attendances, status = 200) =>

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -315,9 +315,7 @@ module.exports = (on) => {
       ]),
     stubOffenderActivitiesOverDateRange: ({ agencyId, fromDate, toDate, period, suspensions }) =>
       Promise.all([prisonApi.stubOffenderActivitiesOverDateRange(agencyId, fromDate, toDate, period, suspensions)]),
-    stubOffenderActivities: (activities) => prisonApi.stubOffenderActivities(activities),
-    stubAttendanceForScheduledActivities: (attendances) =>
-      whereabouts.stubAttendanceForScheduledActivities(attendances),
+    stubPrisonersUnaccountedFor: whereabouts.stubPrisonersUnaccountedFor,
     stubAttendanceForBookings: ({ agencyId, fromDate, toDate, period, attendances }) =>
       whereabouts.stubAttendanceForBookings(agencyId, fromDate, toDate, period, attendances),
     stubAppointments: (appointments) => prisonApi.stubAppointments(appointments),


### PR DESCRIPTION
It still won't be speedy since there are issues with the Prison API endpoint.  Should be a bit better though as only making one call to get the data and also new 30 second timeout on the endpoint.