### PR TITLE
SDI-311 Elastic search for establishment search

### DIFF
--- a/backend/api/offenderSearchApi.test.ts
+++ b/backend/api/offenderSearchApi.test.ts
@@ -120,7 +120,7 @@ describe('offender search api tests', () => {
   })
   describe('GET requests', () => {
     describe('establishment search', () => {
-      it('Passes context properties to request', async () => {
+      it('passes context properties to request', async () => {
         const context = {
           requestHeaders: {
             'page-offset': 10,
@@ -136,7 +136,7 @@ describe('offender search api tests', () => {
         const data = await offenderSearchApi.establishmentSearch(context, 'MDI', {})
         expect(data.length).toEqual(1)
       })
-      it('Passes context properties for some sort fields are mapped', async () => {
+      it('passes mapped context properties for some sort fields', async () => {
         const context = {
           requestHeaders: {
             'page-offset': 10,
@@ -153,7 +153,7 @@ describe('offender search api tests', () => {
         expect(data.length).toEqual(1)
       })
 
-      it('Sets pagination in context from response', async () => {
+      it('sets pagination into context from response', async () => {
         const context: PagingContext = {
           requestHeaders: {
             'page-offset': 10,
@@ -170,7 +170,7 @@ describe('offender search api tests', () => {
         expect(context.responseHeaders).toEqual({ 'page-offset': 3, 'page-limit': 10, 'total-records': 55 })
       })
 
-      it('will modify response content', async () => {
+      it('will modify response content to maintain compatibity with legacy prison-api', async () => {
         const context: PagingContext = {
           requestHeaders: {
             'page-offset': 10,

--- a/backend/api/offenderSearchApi.ts
+++ b/backend/api/offenderSearchApi.ts
@@ -14,7 +14,7 @@ export type PrisonerSearchResult = {
   cellLocation: string
   status: string
   alerts: Array<Alert>
-  categoryCode: string
+  category: string
 }
 
 // other fields are present but only these are used
@@ -22,6 +22,8 @@ export type PrisonerInPrisonSearchResult = PrisonerSearchResult & {
   assignedLivingUnitDesc: string
   alertsDetails: string[]
   age: number
+  categoryCode: string
+  offenderNo: string
 }
 
 export const offenderSearchApiFactory = (client) => {
@@ -73,7 +75,7 @@ export const offenderSearchApiFactory = (client) => {
     return results.map((prisoner) => ({
       ...prisoner,
       // for backward compatibility - treat bookingId as a number
-      bookingId: parseInt(prisoner.bookingId, 10),
+      bookingId: Number(prisoner.bookingId),
       offenderNo: prisoner.prisonerNumber,
       alertsDetails: prisoner.alerts.map((alert: { alertCode: string }) => alert.alertCode),
       assignedLivingUnitDesc: prisoner.cellLocation,

--- a/backend/api/offenderSearchApi.ts
+++ b/backend/api/offenderSearchApi.ts
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import contextProperties from '../contextProperties'
 import { mapToQueryString } from '../utils'
 
@@ -13,6 +14,14 @@ export type PrisonerSearchResult = {
   cellLocation: string
   status: string
   alerts: Array<Alert>
+  categoryCode: string
+}
+
+// other fields are present but only these are used
+export type PrisonerInPrisonSearchResult = PrisonerSearchResult & {
+  assignedLivingUnitDesc: string
+  alertsDetails: string[]
+  age: number
 }
 
 export const offenderSearchApiFactory = (client) => {
@@ -38,6 +47,7 @@ export const offenderSearchApiFactory = (client) => {
     )
 
   const post = (context, url, data) => client.post(context, url, data).then(processResponse(context))
+  const get = (context, url) => client.get(context, url).then(processResponse(context))
 
   const globalSearch = (context, params, pageSizeOverride) => {
     const { page, size } = contextProperties.getPaginationForPageRequest(context)
@@ -47,6 +57,31 @@ export const offenderSearchApiFactory = (client) => {
     )
   }
 
+  const establishmentSearch = async (context, locationId, params): Promise<Array<PrisonerInPrisonSearchResult>> => {
+    const { page, size, sort } = contextProperties.getPaginationForPageRequest(context, (fieldName: string) => {
+      switch (fieldName) {
+        case 'assignedLivingUnitDesc':
+          return 'cellLocation'
+        default:
+          return fieldName
+      }
+    })
+    const results = await get(
+      context,
+      `/prison/${locationId}/prisoners?${mapToQueryString({ ...params, page, size, sort })}`
+    )
+    return results.map((prisoner) => ({
+      ...prisoner,
+      // for backward compatibility - treat bookingId as a number
+      bookingId: parseInt(prisoner.bookingId, 10),
+      offenderNo: prisoner.prisonerNumber,
+      alertsDetails: prisoner.alerts.map((alert: { alertCode: string }) => alert.alertCode),
+      assignedLivingUnitDesc: prisoner.cellLocation,
+      age: moment().diff(prisoner.dateOfBirth, 'years'),
+      categoryCode: prisoner.category,
+    }))
+  }
+
   const getPrisonersDetails = async (context, prisonerNumbers: Array<string>): Promise<Array<PrisonerSearchResult>> => {
     const res = await client.post(context, '/prisoner-search/prisoner-numbers', { prisonerNumbers })
     return res.body
@@ -54,6 +89,7 @@ export const offenderSearchApiFactory = (client) => {
 
   return {
     globalSearch,
+    establishmentSearch,
     getPrisonersDetails,
   }
 }

--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -39,6 +39,26 @@ export type AlertDetails = {
   addedByLastName: string
 }
 
+export type CaseLoad = {
+  caseLoadId: string
+  description: string
+  currentlyActive: boolean
+}
+
+export type Location = {
+  locationPrefix: string
+  description: string
+  locationId: number
+  locationType: string
+  locationUsage: string
+  agencyId: string
+  parentLocationId: number
+  currentOccupancy: number
+  operationalCapacity: number
+  userDescription: string
+  internalLocationCode: string
+}
+
 export const prisonApiFactory = (client) => {
   const processResponse = (context) => (response) => {
     contextProperties.setResponsePagination(context, response.headers)
@@ -57,8 +77,10 @@ export const prisonApiFactory = (client) => {
 
   const put = (context, url, data) => client.put(context, url, data).then(processResponse(context))
 
-  const userLocations = (context) => (context.authSource !== 'auth' ? get(context, '/api/users/me/locations') : [])
-  const userCaseLoads = (context) => (context.authSource !== 'auth' ? get(context, '/api/users/me/caseLoads') : [])
+  const userLocations = (context): [Location] =>
+    context.authSource !== 'auth' ? get(context, '/api/users/me/locations') : []
+  const userCaseLoads = (context): [CaseLoad] =>
+    context.authSource !== 'auth' ? get(context, '/api/users/me/caseLoads') : []
 
   // NB. This function expects a caseload object.
   // The object *must* have non-blank caseLoadId,  description and type properties.

--- a/backend/middleware/currentUser.ts
+++ b/backend/middleware/currentUser.ts
@@ -1,6 +1,12 @@
+import { CaseLoad } from '../api/prisonApi'
 import logger from '../log'
 import { forenameToInitial } from '../utils'
 
+export type User = {
+  allCaseloads: CaseLoad[]
+  displayName: string
+  activeCaseLoad?: CaseLoad
+}
 export default ({ prisonApi, oauthApi }) => {
   const getActiveCaseload = async (req, res) => {
     const { activeCaseLoadId, username } = req.session.userDetails
@@ -38,12 +44,14 @@ export default ({ prisonApi, oauthApi }) => {
 
       const activeCaseLoad = await getActiveCaseload(req, res)
 
-      res.locals.user = {
+      const user: User = {
         ...res.locals.user,
         allCaseloads: req.session.allCaseloads,
         displayName: forenameToInitial(req.session.userDetails.name),
         activeCaseLoad,
       }
+
+      res.locals.user = user
     }
 
     next()

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -244,7 +244,10 @@ const setup = ({
 
   router.use('/attendance-changes', attendanceChangeRouter({ prisonApi, whereaboutsApi }))
 
-  router.use('/prisoner-search', prisonerSearchRouter({ prisonApi, incentivesApi, logError }))
+  router.use(
+    '/prisoner-search',
+    prisonerSearchRouter({ prisonApi, offenderSearchApi, incentivesApi, logError, systemOauthClient })
+  )
 
   router.use(
     '/prisoner/:offenderNo/case-notes/amend-case-note/:caseNoteId',

--- a/backend/routes/prisonerSearchRouter.ts
+++ b/backend/routes/prisonerSearchRouter.ts
@@ -5,8 +5,16 @@ import telemetry from '../azure-appinsights'
 
 const router = express.Router()
 
-const controller = ({ prisonApi, incentivesApi, logError }) => {
-  const { index, post } = prisonerSearchController({ paginationService, prisonApi, incentivesApi, telemetry, logError })
+const controller = ({ prisonApi, offenderSearchApi, incentivesApi, logError, systemOauthClient }) => {
+  const { index, post } = prisonerSearchController({
+    paginationService,
+    prisonApi,
+    offenderSearchApi,
+    incentivesApi,
+    telemetry,
+    logError,
+    systemOauthClient,
+  })
   router.get('/', index)
   router.post('/', post)
 

--- a/backend/tests/contextProperties.test.ts
+++ b/backend/tests/contextProperties.test.ts
@@ -145,6 +145,50 @@ describe('Should read/write properties', () => {
       expect(contextProperties.getPaginationForPageRequest(context)).toStrictEqual({
         page: 2,
         size: 10,
+        sort: undefined,
+      })
+    })
+    it('Should get the request header pagination sort properties', () => {
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'requestHeaders' does not exist on type '... Remove this comment to see the full error message
+      context.requestHeaders = {
+        'page-offset': 20,
+        'page-limit': 10,
+        'sort-fields': 'firstName,lastName',
+        'sort-order': 'ASC',
+      }
+      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{}' is not assignable to paramet... Remove this comment to see the full error message
+      expect(contextProperties.getPaginationForPageRequest(context)).toStrictEqual({
+        page: 2,
+        size: 10,
+        sort: 'firstName,lastName,ASC',
+      })
+    })
+    it('Should map sort propertt field names', () => {
+      expect(
+        contextProperties.getPaginationForPageRequest(
+          {
+            requestHeaders: {
+              'page-offset': 20,
+              'page-limit': 10,
+              'sort-fields': 'firstName,lastName',
+              'sort-order': 'DESC',
+            },
+          },
+          (fieldName) => {
+            switch (fieldName) {
+              case 'firstName':
+                return 'forename'
+              case 'lastName':
+                return 'surname'
+              default:
+                return fieldName
+            }
+          }
+        )
+      ).toStrictEqual({
+        page: 2,
+        size: 10,
+        sort: 'forename,surname,DESC',
       })
     })
   })

--- a/backend/tests/prisonerSearch.test.ts
+++ b/backend/tests/prisonerSearch.test.ts
@@ -537,7 +537,7 @@ describe('Prisoner search', () => {
       expect(offenderSearchApi.establishmentSearch).toHaveBeenCalledTimes(0)
     })
 
-    it('should not even make a request location is not in any of the users caseload', async () => {
+    it('should not even make a request when location is not in any of the users caseloads', async () => {
       req.query.location = 'FXI'
 
       await controller.index(req, res)

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -177,6 +177,7 @@ module.exports = defineConfig({
         stubAlerts: prisonApi.stubAlerts,
 
         stubInmates: prisonApi.stubInmates,
+        stubPSInmates: offenderSearch.stubInmates,
         stubUserLocations: prisonApi.stubUserLocations,
 
         stubQuickLook: ({

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   digital-prison-services-wiremock:
-    image: rodolpheche/wiremock
+    image: wiremock/wiremock
     container_name: digital-prison-services-test-wiremock
     restart: unless-stopped
     ports:

--- a/integration-tests/integration/search/prisonerSearch.cy.js
+++ b/integration-tests/integration/search/prisonerSearch.cy.js
@@ -1,37 +1,12 @@
+const moment = require('moment')
 const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const { quickLookFullDetails } = require('../prisonerProfile/prisonerQuickLook.cy')
 
 context('Prisoner search', () => {
-  const inmate1 = {
-    bookingId: 1,
-    offenderNo: 'A1234BC',
-    firstName: 'JOHN',
-    lastName: 'SAUNDERS',
-    dateOfBirth: '1990-10-12',
-    age: 29,
-    agencyId: 'MDI',
-    assignedLivingUnitId: 1,
-    assignedLivingUnitDesc: 'UNIT-1',
-    categoryCode: 'A',
-    alertsDetails: ['XA', 'XVL'],
-  }
   const inmate1Iep = {
     bookingId: 1,
     iepLevel: 'Standard',
-  }
-  const inmate2 = {
-    bookingId: 2,
-    offenderNo: 'B4567CD',
-    firstName: 'STEVE',
-    lastName: 'SMITH',
-    dateOfBirth: '1989-11-12',
-    age: 30,
-    agencyId: 'MDI',
-    assignedLivingUnitId: 2,
-    assignedLivingUnitDesc: 'UNIT-2',
-    categoryCode: 'C',
-    alertsDetails: ['RSS', 'XC'],
   }
   const inmate2Iep = {
     bookingId: 2,
@@ -41,7 +16,22 @@ context('Prisoner search', () => {
   before(() => {
     cy.clearCookies()
     cy.task('resetAndStubTokenVerification')
-    cy.task('stubSignIn', { username: 'ITAG_USER', caseload: 'MDI' })
+    cy.task('stubSignIn', {
+      username: 'ITAG_USER',
+      caseload: 'MDI',
+      caseloads: [
+        {
+          caseLoadId: 'MDI',
+          description: 'Moorland',
+          currentlyActive: true,
+        },
+        {
+          caseLoadId: 'WWI',
+          description: 'Wandsworth',
+          currentlyActive: false,
+        },
+      ],
+    })
     cy.signIn()
   })
 
@@ -49,227 +39,536 @@ context('Prisoner search', () => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
   })
 
-  context('When there are no search values', () => {
-    beforeEach(() => {
-      cy.task('stubUserLocations')
+  context('Search using prison-api', () => {
+    const inmate1 = {
+      bookingId: 1,
+      offenderNo: 'A1234BC',
+      firstName: 'JOHN',
+      lastName: 'SAUNDERS',
+      dateOfBirth: '1990-10-12',
+      age: 29,
+      agencyId: 'MDI',
+      assignedLivingUnitId: 1,
+      assignedLivingUnitDesc: 'UNIT-1',
+      categoryCode: 'A',
+      alertsDetails: ['XA', 'XVL'],
+    }
+
+    const inmate2 = {
+      bookingId: 2,
+      offenderNo: 'B4567CD',
+      firstName: 'STEVE',
+      lastName: 'SMITH',
+      dateOfBirth: '1989-11-12',
+      age: 30,
+      agencyId: 'MDI',
+      assignedLivingUnitId: 2,
+      assignedLivingUnitDesc: 'UNIT-2',
+      categoryCode: 'C',
+      alertsDetails: ['RSS', 'XC'],
+    }
+
+    context('When there are no search values', () => {
+      beforeEach(() => {
+        cy.task('stubUserLocations')
+      })
+
+      it('should display correct prisoner information', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search`)
+
+        cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
+          cy.get($table)
+            .find('tr')
+            .then(($tableRows) => {
+              cy.get($tableRows).its('length').should('eq', 3) // 2 results plus table header
+              expect($tableRows.get(1).innerText).to.contain(
+                '\tSaunders, John\tA1234BC\tUNIT-1\tStandard\t29\t\nARSONIST\n\nCAT A'
+              )
+              expect($tableRows.get(2).innerText).to.contain('\tSmith, Steve\tB4567CD\tUNIT-2\tStandard\t30\t')
+            })
+        })
+      })
     })
 
-    it('should display correct prisoner information', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 2,
-        data: [inmate1, inmate2],
+    context('When there are search values', () => {
+      beforeEach(() => {
+        cy.task('stubUserLocations')
       })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
-      cy.visit(`/prisoner-search`)
 
-      cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
-        cy.get($table)
-          .find('tr')
-          .then(($tableRows) => {
-            cy.get($tableRows).its('length').should('eq', 3) // 2 results plus table header
-            expect($tableRows.get(1).innerText).to.contain(
-              '\tSaunders, John\tA1234BC\tUNIT-1\tStandard\t29\t\nARSONIST\n\nCAT A'
-            )
-            expect($tableRows.get(2).innerText).to.contain('\tSmith, Steve\tB4567CD\tUNIT-2\tStandard\t30\t')
-          })
+      it('should have correct data pre filled from search query', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 1,
+          data: [inmate1],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
+        cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA`)
+
+        cy.get('[data-test="prisoner-search-keywords"]').should('have.value', 'Saunders')
+        cy.get('[data-test="prisoner-search-location"]').should('have.value', 'MDI')
+        cy.get('[data-test="prisoner-search-alerts-container"]').should('have.attr', 'open')
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('have.attr', 'checked')
+            })
+        })
+      })
+
+      it('should clear be able to clear selected alerts', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 1,
+          data: [inmate1],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
+        cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA`)
+
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('have.attr', 'checked')
+            })
+        })
+
+        cy.get('[data-test="prisoner-search-clear-alerts"]').click()
+        cy.get('[data-test="prisoner-search-form"]').submit()
+        cy.get('[data-test="prisoner-search-alerts-container"]').should('not.have.attr', 'open')
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('not.have.attr', 'checked')
+            })
+        })
+      })
+
+      it('should show correct order options for list view', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search`)
+
+        cy.get('[data-test="prisoner-search-order"]').then(($select) => {
+          cy.get($select)
+            .find('option')
+            .then(($options) => {
+              cy.get($options).its('length').should('eq', 6)
+              cy.get($options.get(0)).should('have.value', 'lastName,firstName:ASC')
+              cy.get($options.get(1)).should('have.value', 'lastName,firstName:DESC')
+              cy.get($options.get(2)).should('have.value', 'assignedLivingUnitDesc:ASC')
+              cy.get($options.get(3)).should('have.value', 'assignedLivingUnitDesc:DESC')
+              cy.get($options.get(4)).should('have.value', 'dateOfBirth:DESC')
+              cy.get($options.get(5)).should('have.value', 'dateOfBirth:ASC')
+            })
+        })
+      })
+
+      it('should show view all results link and then hide when clicked', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?pageLimitOption=1`)
+
+        cy.get('[data-test="prisoner-search-view-all-link"]').then(($link) => {
+          cy.get($link).should('contain.text', 'View all results').click()
+          cy.get($link).should('not.exist')
+        })
+      })
+
+      it('should show correct order options for grid view', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?view=grid`)
+
+        cy.get('[data-test="prisoner-search-order"]').then(($select) => {
+          cy.get($select)
+            .find('option')
+            .then(($options) => {
+              cy.get($options).its('length').should('eq', 4)
+              cy.get($options.get(0)).should('have.value', 'lastName,firstName:ASC')
+              cy.get($options.get(1)).should('have.value', 'lastName,firstName:DESC')
+              cy.get($options.get(2)).should('have.value', 'assignedLivingUnitDesc:ASC')
+              cy.get($options.get(3)).should('have.value', 'assignedLivingUnitDesc:DESC')
+            })
+        })
+      })
+
+      it('should have the correct link to the prisoner profile', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?view=grid`)
+
+        cy.get('[data-test="prisoner-profile-link"]').then(($prisonerProfileLinks) => {
+          cy.get($prisonerProfileLinks).its('length').should('eq', 2)
+          cy.get($prisonerProfileLinks.get(0)).should('have.attr', 'href').should('include', '/prisoner/A1234BC')
+          cy.get($prisonerProfileLinks.get(1)).should('have.attr', 'href').should('include', '/prisoner/B4567CD')
+        })
+      })
+
+      it('should maintain search options when sorting', () => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA`)
+
+        cy.get('[data-test="prisoner-search-order"]').select('assignedLivingUnitDesc:ASC')
+        cy.get('[data-test="prisoner-search-order-form-submit"]').should('contain.text', 'Reorder')
+        cy.get('[data-test="prisoner-search-order-form"]').submit()
+
+        cy.get('[data-test="prisoner-search-keywords"]').should('have.value', 'Saunders')
+        cy.get('[data-test="prisoner-search-location"]').should('have.value', 'MDI')
+        cy.get('[data-test="prisoner-search-alerts-container"]').should('have.attr', 'open')
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('have.attr', 'checked')
+            })
+        })
+
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq(
+            '?keywords=Saunders&location=MDI&alerts%5B%5D=XA&sortFieldsWithOrder=assignedLivingUnitDesc%3AASC'
+          )
+        })
+      })
+
+      it('should show the correct most recent search link when visiting a profile page from search', () => {
+        const searchUrl = '/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA'
+
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 1,
+          data: [inmate1],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
+        cy.task('stubPrisonerProfileHeaderData', {
+          offenderBasicDetails,
+          offenderFullDetails,
+          iepSummary: [inmate1Iep],
+          caseNoteSummary: {},
+          offenderNo: 'A12345',
+        })
+        cy.task('stubQuickLook', quickLookFullDetails)
+        cy.task('stubPathFinderOffenderDetails', null)
+        cy.task('stubClientCredentialsRequest')
+        cy.visit(searchUrl)
+
+        cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
+          cy.get($table)
+            .find('tr')
+            .then(($tableRows) => {
+              cy.get($tableRows).find('a').click()
+            })
+        })
+
+        cy.get('[data-test="recent-search-link"]').should('have.attr', 'href', searchUrl)
       })
     })
   })
 
-  context('When there are search values', () => {
-    beforeEach(() => {
-      cy.task('stubUserLocations')
-    })
+  context('Search using search api', () => {
+    const inmate1 = {
+      bookingId: '1',
+      prisonerNumber: 'A1234BC',
+      firstName: 'JOHN',
+      lastName: 'SAUNDERS',
+      dateOfBirth: moment().subtract(29, 'years'),
+      prisonId: 'MDI',
+      cellLocation: 'UNIT-1',
+      category: 'A',
+      alerts: [{ alertCode: 'XA' }, { alertCode: 'XVL' }],
+    }
 
-    it('should have correct data pre filled from search query', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 1,
-        data: [inmate1],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
-      cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA`)
+    const inmate2 = {
+      bookingId: '2',
+      prisonerNumber: 'B4567CD',
+      firstName: 'STEVE',
+      lastName: 'SMITH',
+      dateOfBirth: moment().subtract(30, 'years'),
+      prisonId: 'MDI',
+      cellLocation: 'UNIT-2',
+      category: 'C',
+      alerts: [{ alertCode: 'RSS' }, { alertCode: 'XC' }],
+    }
 
-      cy.get('[data-test="prisoner-search-keywords"]').should('have.value', 'Saunders')
-      cy.get('[data-test="prisoner-search-location"]').should('have.value', 'MDI')
-      cy.get('[data-test="prisoner-search-alerts-container"]').should('have.attr', 'open')
-      cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
-        cy.get($alerts)
-          .find('input')
-          .then(($inputs) => {
-            cy.get($inputs.get(2)).should('have.attr', 'checked')
-          })
-      })
-    })
-
-    it('should clear be able to clear selected alerts', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 1,
-        data: [inmate1],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
-      cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA`)
-
-      cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
-        cy.get($alerts)
-          .find('input')
-          .then(($inputs) => {
-            cy.get($inputs.get(2)).should('have.attr', 'checked')
-          })
+    context('When there are no search values', () => {
+      beforeEach(() => {
+        cy.task('stubUserLocations')
       })
 
-      cy.get('[data-test="prisoner-search-clear-alerts"]').click()
-      cy.get('[data-test="prisoner-search-form"]').submit()
-      cy.get('[data-test="prisoner-search-alerts-container"]').should('not.have.attr', 'open')
-      cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
-        cy.get($alerts)
-          .find('input')
-          .then(($inputs) => {
-            cy.get($inputs.get(2)).should('not.have.attr', 'checked')
-          })
-      })
-    })
+      it('should display correct prisoner information', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?feature=new`)
 
-    it('should show correct order options for list view', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 2,
-        data: [inmate1, inmate2],
+        cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
+          cy.get($table)
+            .find('tr')
+            .then(($tableRows) => {
+              cy.get($tableRows).its('length').should('eq', 3) // 2 results plus table header
+              expect($tableRows.get(1).innerText).to.contain(
+                '\tSaunders, John\tA1234BC\tUNIT-1\tStandard\t29\t\nARSONIST\n\nCAT A'
+              )
+              expect($tableRows.get(2).innerText).to.contain('\tSmith, Steve\tB4567CD\tUNIT-2\tStandard\t30\t')
+            })
+        })
       })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
-      cy.visit(`/prisoner-search`)
+      it('can search for prisoners when in caseload that is not active', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'WWI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?location=WWI&feature=new`)
 
-      cy.get('[data-test="prisoner-search-order"]').then(($select) => {
-        cy.get($select)
-          .find('option')
-          .then(($options) => {
-            cy.get($options).its('length').should('eq', 6)
-            cy.get($options.get(0)).should('have.value', 'lastName,firstName:ASC')
-            cy.get($options.get(1)).should('have.value', 'lastName,firstName:DESC')
-            cy.get($options.get(2)).should('have.value', 'assignedLivingUnitDesc:ASC')
-            cy.get($options.get(3)).should('have.value', 'assignedLivingUnitDesc:DESC')
-            cy.get($options.get(4)).should('have.value', 'dateOfBirth:DESC')
-            cy.get($options.get(5)).should('have.value', 'dateOfBirth:ASC')
-          })
+        cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
+          cy.get($table)
+            .find('tr')
+            .then(($tableRows) => {
+              cy.get($tableRows).its('length').should('eq', 3) // 2 results plus table header
+            })
+        })
       })
-    })
+      it('will silently not find any prisoners when prison is not in any caseload assighned to user', () => {
+        // stubbed - but actually it will never be clalled
+        cy.task('stubPSInmates', {
+          locationId: 'BXI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?location=BXI&feature=new`)
 
-    it('should show view all results link and then hide when clicked', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 2,
-        data: [inmate1, inmate2],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
-      cy.visit(`/prisoner-search?pageLimitOption=1`)
-
-      cy.get('[data-test="prisoner-search-view-all-link"]').then(($link) => {
-        cy.get($link).should('contain.text', 'View all results').click()
-        cy.get($link).should('not.exist')
+        cy.contains('No records found matching search criteria')
       })
     })
 
-    it('should show correct order options for grid view', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 2,
-        data: [inmate1, inmate2],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
-      cy.visit(`/prisoner-search?view=grid`)
-
-      cy.get('[data-test="prisoner-search-order"]').then(($select) => {
-        cy.get($select)
-          .find('option')
-          .then(($options) => {
-            cy.get($options).its('length').should('eq', 4)
-            cy.get($options.get(0)).should('have.value', 'lastName,firstName:ASC')
-            cy.get($options.get(1)).should('have.value', 'lastName,firstName:DESC')
-            cy.get($options.get(2)).should('have.value', 'assignedLivingUnitDesc:ASC')
-            cy.get($options.get(3)).should('have.value', 'assignedLivingUnitDesc:DESC')
-          })
-      })
-    })
-
-    it('should have the correct link to the prisoner profile', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 2,
-        data: [inmate1, inmate2],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
-      cy.visit(`/prisoner-search?view=grid`)
-
-      cy.get('[data-test="prisoner-profile-link"]').then(($prisonerProfileLinks) => {
-        cy.get($prisonerProfileLinks).its('length').should('eq', 2)
-        cy.get($prisonerProfileLinks.get(0)).should('have.attr', 'href').should('include', '/prisoner/A1234BC')
-        cy.get($prisonerProfileLinks.get(1)).should('have.attr', 'href').should('include', '/prisoner/B4567CD')
-      })
-    })
-
-    it('should maintain search options when sorting', () => {
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 2,
-        data: [inmate1, inmate2],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
-      cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA`)
-
-      cy.get('[data-test="prisoner-search-order"]').select('assignedLivingUnitDesc:ASC')
-      cy.get('[data-test="prisoner-search-order-form-submit"]').should('contain.text', 'Reorder')
-      cy.get('[data-test="prisoner-search-order-form"]').submit()
-
-      cy.get('[data-test="prisoner-search-keywords"]').should('have.value', 'Saunders')
-      cy.get('[data-test="prisoner-search-location"]').should('have.value', 'MDI')
-      cy.get('[data-test="prisoner-search-alerts-container"]').should('have.attr', 'open')
-      cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
-        cy.get($alerts)
-          .find('input')
-          .then(($inputs) => {
-            cy.get($inputs.get(2)).should('have.attr', 'checked')
-          })
+    context('When there are search values', () => {
+      beforeEach(() => {
+        cy.task('stubUserLocations')
       })
 
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq(
-          '?keywords=Saunders&location=MDI&alerts%5B%5D=XA&sortFieldsWithOrder=assignedLivingUnitDesc%3AASC'
-        )
-      })
-    })
+      it('should have correct data pre filled from search query', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 1,
+          data: [inmate1],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
+        cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA&feature=new`)
 
-    it('should show the correct most recent search link when visiting a profile page from search', () => {
-      const searchUrl = '/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA'
-
-      cy.task('stubInmates', {
-        locationId: 'MDI',
-        count: 1,
-        data: [inmate1],
-      })
-      cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
-      cy.task('stubPrisonerProfileHeaderData', {
-        offenderBasicDetails,
-        offenderFullDetails,
-        iepSummary: [inmate1Iep],
-        caseNoteSummary: {},
-        offenderNo: 'A12345',
-      })
-      cy.task('stubQuickLook', quickLookFullDetails)
-      cy.task('stubPathFinderOffenderDetails', null)
-      cy.task('stubClientCredentialsRequest')
-      cy.visit(searchUrl)
-
-      cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
-        cy.get($table)
-          .find('tr')
-          .then(($tableRows) => {
-            cy.get($tableRows).find('a').click()
-          })
+        cy.get('[data-test="prisoner-search-keywords"]').should('have.value', 'Saunders')
+        cy.get('[data-test="prisoner-search-location"]').should('have.value', 'MDI')
+        cy.get('[data-test="prisoner-search-alerts-container"]').should('have.attr', 'open')
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('have.attr', 'checked')
+            })
+        })
       })
 
-      cy.get('[data-test="recent-search-link"]').should('have.attr', 'href', searchUrl)
+      it('should clear be able to clear selected alerts', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 1,
+          data: [inmate1],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
+        cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA&feature=new`)
+
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('have.attr', 'checked')
+            })
+        })
+
+        cy.get('[data-test="prisoner-search-clear-alerts"]').click()
+        cy.get('[data-test="prisoner-search-form"]').submit()
+        cy.get('[data-test="prisoner-search-alerts-container"]').should('not.have.attr', 'open')
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('not.have.attr', 'checked')
+            })
+        })
+      })
+
+      it('should show correct order options for list view', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search`)
+
+        cy.get('[data-test="prisoner-search-order"]').then(($select) => {
+          cy.get($select)
+            .find('option')
+            .then(($options) => {
+              cy.get($options).its('length').should('eq', 6)
+              cy.get($options.get(0)).should('have.value', 'lastName,firstName:ASC')
+              cy.get($options.get(1)).should('have.value', 'lastName,firstName:DESC')
+              cy.get($options.get(2)).should('have.value', 'assignedLivingUnitDesc:ASC')
+              cy.get($options.get(3)).should('have.value', 'assignedLivingUnitDesc:DESC')
+              cy.get($options.get(4)).should('have.value', 'dateOfBirth:DESC')
+              cy.get($options.get(5)).should('have.value', 'dateOfBirth:ASC')
+            })
+        })
+      })
+
+      it('should show view all results link and then hide when clicked', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?pageLimitOption=1&feature=new`)
+
+        cy.get('[data-test="prisoner-search-view-all-link"]').then(($link) => {
+          cy.get($link).should('contain.text', 'View all results').click()
+          cy.get($link).should('not.exist')
+        })
+      })
+
+      it('should show correct order options for grid view', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?view=grid`)
+
+        cy.get('[data-test="prisoner-search-order"]').then(($select) => {
+          cy.get($select)
+            .find('option')
+            .then(($options) => {
+              cy.get($options).its('length').should('eq', 4)
+              cy.get($options.get(0)).should('have.value', 'lastName,firstName:ASC')
+              cy.get($options.get(1)).should('have.value', 'lastName,firstName:DESC')
+              cy.get($options.get(2)).should('have.value', 'assignedLivingUnitDesc:ASC')
+              cy.get($options.get(3)).should('have.value', 'assignedLivingUnitDesc:DESC')
+            })
+        })
+      })
+
+      it('should have the correct link to the prisoner profile', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?view=grid&feature=new`)
+
+        cy.get('[data-test="prisoner-profile-link"]').then(($prisonerProfileLinks) => {
+          cy.get($prisonerProfileLinks).its('length').should('eq', 2)
+          cy.get($prisonerProfileLinks.get(0)).should('have.attr', 'href').should('include', '/prisoner/A1234BC')
+          cy.get($prisonerProfileLinks.get(1)).should('have.attr', 'href').should('include', '/prisoner/B4567CD')
+        })
+      })
+
+      it('should maintain search options when sorting', () => {
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep, inmate2Iep])
+        cy.visit(`/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA&feature=new`)
+
+        cy.get('[data-test="prisoner-search-order"]').select('assignedLivingUnitDesc:ASC')
+        cy.get('[data-test="prisoner-search-order-form-submit"]').should('contain.text', 'Reorder')
+        cy.get('[data-test="prisoner-search-order-form"]').submit()
+
+        cy.get('[data-test="prisoner-search-keywords"]').should('have.value', 'Saunders')
+        cy.get('[data-test="prisoner-search-location"]').should('have.value', 'MDI')
+        cy.get('[data-test="prisoner-search-alerts-container"]').should('have.attr', 'open')
+        cy.get('[data-test="prisoner-search-alerts"]').then(($alerts) => {
+          cy.get($alerts)
+            .find('input')
+            .then(($inputs) => {
+              cy.get($inputs.get(2)).should('have.attr', 'checked')
+            })
+        })
+
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq(
+            '?keywords=Saunders&location=MDI&feature=new&alerts%5B%5D=XA&sortFieldsWithOrder=assignedLivingUnitDesc%3AASC'
+          )
+        })
+      })
+
+      it('should show the correct most recent search link when visiting a profile page from search', () => {
+        const searchUrl = '/prisoner-search?keywords=Saunders&location=MDI&alerts%5B%5D=XA&feature=new'
+
+        cy.task('stubPSInmates', {
+          locationId: 'MDI',
+          count: 1,
+          data: [inmate1],
+        })
+        cy.task('stubGetIepSummaryForBookingIds', [inmate1Iep])
+        cy.task('stubPrisonerProfileHeaderData', {
+          offenderBasicDetails,
+          offenderFullDetails,
+          iepSummary: [inmate1Iep],
+          caseNoteSummary: {},
+          offenderNo: 'A12345',
+        })
+        cy.task('stubQuickLook', quickLookFullDetails)
+        cy.task('stubPathFinderOffenderDetails', null)
+        cy.task('stubClientCredentialsRequest')
+        cy.visit(searchUrl)
+
+        cy.get('[data-test="prisoner-search-results-table"]').then(($table) => {
+          cy.get($table)
+            .find('tr')
+            .then(($tableRows) => {
+              cy.get($tableRows).find('a').click()
+            })
+        })
+
+        cy.get('[data-test="recent-search-link"]').should('have.attr', 'href', searchUrl)
+      })
     })
   })
 })

--- a/integration-tests/mockApis/offenderSearch.js
+++ b/integration-tests/mockApis/offenderSearch.js
@@ -108,4 +108,19 @@ module.exports = {
         jsonBody: response,
       },
     }),
+  stubInmates: ({ locationId, params, count, data = [] }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: `/offenderSearch/prison/${locationId}/prisoners`,
+        queryParameters: params,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: { content: data, totalElements: count, pageable: { pageSize: 50, offset: 0 } },
+      },
+    }),
 }


### PR DESCRIPTION
1. Adds integration to `prisoner-offender-search` for the main DPS (establishment) search
2. Existing `prison-api` search is used by default
3. `prisoner-offender-search` can be used by adding `feature=new` to any /prisoner-search url
4. Old behaviour is replicated