### PR TITLE
INC-814: Improve incentives api types

### DIFF
--- a/backend/api/incentivesApi.ts
+++ b/backend/api/incentivesApi.ts
@@ -1,7 +1,8 @@
+import type { ClientContext, OauthApiClient } from './oauthEnabledClient'
 import contextProperties from '../contextProperties'
 
-export const incentivesApiFactory = (client) => {
-  const processResponse = (context) => (response) => {
+export const incentivesApiFactory = (client: OauthApiClient) => {
+  const processResponse = (context: ClientContext) => (response) => {
     contextProperties.setResponsePagination(context, response.headers)
     return response.body
   }

--- a/backend/api/incentivesApi.ts
+++ b/backend/api/incentivesApi.ts
@@ -15,17 +15,22 @@ export type IepSummaryForBooking = {
   iepDate: string
   iepTime: string
   daysSinceReview: number
-  iepDetails: {
-    bookingId: number
-    iepLevel: string
-    iepDate: string
-    iepTime: string
-    comments: string
-    agencyId: string
-    userId: string | null
-    // also available
-    // auditModuleName: string
-  }[]
+}
+
+export type IepSummaryDetail = {
+  bookingId: number
+  iepLevel: string
+  iepDate: string
+  iepTime: string
+  comments: string
+  agencyId: string
+  userId: string | null
+  // also available
+  // auditModuleName: string
+}
+
+export type IepSummaryForBookingWithDetails = IepSummaryForBooking & {
+  iepDetails: IepSummaryDetail[]
 }
 
 export type IepSummaryForBookingId = {
@@ -71,12 +76,15 @@ export const incentivesApiFactory = (client: OauthApiClient) => {
   const getAgencyIepLevels = (context: ClientContext, agencyId: string): Promise<AgencyIepLevel[]> =>
     get<AgencyIepLevel[]>(context, `/iep/levels/${agencyId}`)
 
-  const getIepSummaryForBooking = (
+  type GetIepSummaryForBooking = {
+    (context: ClientContext, bookingId: number, withDetails?: false): Promise<IepSummaryForBooking>
+    (context: ClientContext, bookingId: number, withDetails: true): Promise<IepSummaryForBookingWithDetails>
+  }
+  const getIepSummaryForBooking: GetIepSummaryForBooking = (
     context: ClientContext,
     bookingId: number,
     withDetails = false
-  ): Promise<IepSummaryForBooking> =>
-    get<IepSummaryForBooking>(context, `/iep/reviews/booking/${bookingId}?with-details=${withDetails}`)
+  ): Promise<any> => get(context, `/iep/reviews/booking/${bookingId}?with-details=${withDetails}`)
 
   const getIepSummaryForBookingIds = (
     context: ClientContext,

--- a/backend/api/incentivesApi.ts
+++ b/backend/api/incentivesApi.ts
@@ -1,24 +1,91 @@
+import type { Response } from 'superagent'
 import type { ClientContext, OauthApiClient } from './oauthEnabledClient'
 import contextProperties from '../contextProperties'
 
+export type AgencyIepLevel = {
+  iepLevel: string
+  iepDescription: string
+  sequence: number
+  default: boolean
+}
+
+export type IepSummaryForBooking = {
+  bookingId: number
+  iepLevel: string
+  iepDate: string
+  iepTime: string
+  daysSinceReview: number
+  iepDetails: {
+    bookingId: number
+    iepLevel: string
+    iepDate: string
+    iepTime: string
+    comments: string
+    agencyId: string
+    userId: string | null
+    // also available
+    // auditModuleName: string
+  }[]
+}
+
+export type IepSummaryForBookingId = {
+  bookingId: number
+  iepLevel: string
+}
+
+export type IepLevelChangeRequest = {
+  iepLevel: string
+  comment: string
+}
+
+export type IepLevelChanged = {
+  bookingId: number
+  iepDate: string
+  iepTime: string
+  iepLevel: string
+  comments: string
+  // also available
+  // id: number
+  // prisonerNumber: string
+  // agencyId: string
+  // locationId: string
+  // userId: string
+  // reviewType: string
+  // auditModuleName: string
+}
+
 export const incentivesApiFactory = (client: OauthApiClient) => {
-  const processResponse = (context: ClientContext) => (response) => {
-    contextProperties.setResponsePagination(context, response.headers)
-    return response.body
-  }
+  const processResponse =
+    <T>(context: ClientContext) =>
+    (response: Response): T => {
+      contextProperties.setResponsePagination(context, response.headers)
+      return response.body
+    }
 
-  const get = (context, url) => client.get(context, url).then(processResponse(context))
+  const get = <T>(context: ClientContext, url: string): Promise<T> =>
+    client.get<T>(context, url).then(processResponse(context))
 
-  const post = (context, url, data) => client.post(context, url, data).then(processResponse(context))
+  const post = <T, Body>(context: ClientContext, url: string, data: Body): Promise<T> =>
+    client.post<T>(context, url, data).then(processResponse(context))
 
-  const getAgencyIepLevels = (context, agencyId) => get(context, `/iep/levels/${agencyId}`)
+  const getAgencyIepLevels = (context: ClientContext, agencyId: string): Promise<AgencyIepLevel[]> =>
+    get<AgencyIepLevel[]>(context, `/iep/levels/${agencyId}`)
 
-  const getIepSummaryForBooking = (context, bookingId, withDetails) =>
-    get(context, `/iep/reviews/booking/${bookingId}?with-details=${withDetails}`)
+  const getIepSummaryForBooking = (
+    context: ClientContext,
+    bookingId: number,
+    withDetails = false
+  ): Promise<IepSummaryForBooking> =>
+    get<IepSummaryForBooking>(context, `/iep/reviews/booking/${bookingId}?with-details=${withDetails}`)
 
-  const getIepSummaryForBookingIds = (context, bookingIds) => post(context, `/iep/reviews/bookings`, bookingIds)
+  const getIepSummaryForBookingIds = (
+    context: ClientContext,
+    bookingIds: number[]
+  ): Promise<IepSummaryForBookingId[]> =>
+    post<IepSummaryForBookingId[], number[]>(context, '/iep/reviews/bookings', bookingIds)
 
-  const changeIepLevel = (context, bookingId, body) => post(context, `/iep/reviews/booking/${bookingId}`, body)
+  const changeIepLevel = (context: ClientContext, bookingId: number, body: IepLevelChangeRequest) =>
+    post<IepLevelChanged, IepLevelChangeRequest>(context, `/iep/reviews/booking/${bookingId}`, body)
 
   return {
     getAgencyIepLevels,

--- a/backend/api/oauthEnabledClient.ts
+++ b/backend/api/oauthEnabledClient.ts
@@ -23,7 +23,7 @@ type OauthApiClientOptions = {
   timeout?: number
 }
 
-type ClientResponse<T = never> = {
+type ClientResponse<T = any> = {
   body: T
   req: ClientRequest
 } & superagent.Response
@@ -118,7 +118,7 @@ export class OauthApiClient {
    * @param body
    * @returns A Promise which resolves to the superagent result object, or the superagent error object if it is rejected
    */
-  post = <T>(context: ClientContext, path: string, body: never): Promise<ClientResponse<T>> => {
+  post = <T>(context: ClientContext, path: string, body: any): Promise<ClientResponse<T>> => {
     return superagent
       .post(this.createUrl(path))
       .send(body)
@@ -136,7 +136,7 @@ export class OauthApiClient {
    * @param body
    * @returns A Promise which resolves to the superagent result object, or the superagent error object if it is rejected
    */
-  put = <T>(context: ClientContext, path: string, body: never): Promise<ClientResponse<T>> => {
+  put = <T>(context: ClientContext, path: string, body: any): Promise<ClientResponse<T>> => {
     return superagent
       .put(this.createUrl(path))
       .send(body)

--- a/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.ts
@@ -1,9 +1,16 @@
 import moment from 'moment'
 import config from '../../config'
+import type apis from '../../apis'
 import { putLastNameFirst, formatName } from '../../utils'
 import { raiseAnalyticsEvent } from '../../raiseAnalyticsEvent'
 
-export default ({ prisonApi, incentivesApi }) => {
+export default ({
+  prisonApi,
+  incentivesApi,
+}: {
+  prisonApi: typeof apis.prisonApi
+  incentivesApi: typeof apis.incentivesApi
+}) => {
   const renderTemplate = async (req, res, pageData) => {
     const { offenderNo } = req.params
     const { errors, formValues = {} } = pageData || {}

--- a/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.ts
@@ -20,7 +20,7 @@ export default ({
       const { agencyId, bookingId, firstName, lastName } = prisonerDetails
 
       const [iepSummary, iepLevels] = await Promise.all([
-        incentivesApi.getIepSummaryForBooking(res.locals, bookingId, true),
+        incentivesApi.getIepSummaryForBooking(res.locals, bookingId),
         incentivesApi.getAgencyIepLevels(res.locals, agencyId),
       ])
 

--- a/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.ts
@@ -57,7 +57,7 @@ export default ({
       const { agencyId, bookingId, firstName, lastName, assignedLivingUnit } = prisonerDetails
       const locationId: string | undefined = assignedLivingUnit?.description
 
-      const iepSummary = await incentivesApi.getIepSummaryForBooking(res.locals, bookingId, false)
+      const iepSummary = await incentivesApi.getIepSummaryForBooking(res.locals, bookingId)
       // TODO: nextReviewDate will come from incentivesApi in future
       const nextReviewDate = iepSummary?.iepTime && moment(iepSummary.iepTime, 'YYYY-MM-DD HH:mm').add(1, 'years')
 

--- a/backend/controllers/prisonerProfile/prisonerIncentiveLevelDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerIncentiveLevelDetails.ts
@@ -1,4 +1,5 @@
 import moment from 'moment'
+import type apis from '../../apis'
 import { putLastNameFirst, properCaseName, formatName, daysSince } from '../../utils'
 
 const filterData = (data, fields) => {
@@ -24,7 +25,15 @@ const filterData = (data, fields) => {
   return filteredResults
 }
 
-export default ({ prisonApi, incentivesApi, oauthApi }) =>
+export default ({
+    prisonApi,
+    incentivesApi,
+    oauthApi,
+  }: {
+    prisonApi: typeof apis.prisonApi
+    incentivesApi: typeof apis.incentivesApi
+    oauthApi: typeof apis.oauthApi
+  }) =>
   async (req, res) => {
     const { offenderNo } = req.params
     const { agencyId, incentiveLevel, fromDate, toDate } = req.query

--- a/backend/controllers/prisonerProfile/prisonerQuickLook.ts
+++ b/backend/controllers/prisonerProfile/prisonerQuickLook.ts
@@ -1,10 +1,11 @@
 import moment from 'moment'
+import log from '../../log'
 import { daysSince, formatCurrency } from '../../utils'
 import formatAward from '../../shared/formatAward'
 import filterActivitiesByPeriod from '../../shared/filterActivitiesByPeriod'
 import getValueByType from '../../shared/getValueByType'
-import log from '../../log'
 import getContext from './prisonerProfileContext'
+import type apis from '../../apis'
 
 export const trackEvent = (telemetry, username, activeCaseLoad) => {
   if (telemetry) {
@@ -71,6 +72,16 @@ export default ({
     oauthApi,
     restrictedPatientApi,
     logError,
+  }: {
+    prisonerProfileService
+    prisonApi
+    telemetry
+    offenderSearchApi
+    systemOauthClient
+    incentivesApi: typeof apis.incentivesApi
+    oauthApi
+    restrictedPatientApi
+    logError
   }) =>
   async (req, res) => {
     const {
@@ -113,7 +124,7 @@ export default ({
         prisonApi.getPrisonerBalances(context, bookingId),
         prisonApi.getPrisonerDetails(context, offenderNo),
         prisonApi.getPrisonerSentenceDetails(context, offenderNo),
-        incentivesApi.getIepSummaryForBooking(context, bookingId, false),
+        incentivesApi.getIepSummaryForBooking(context, bookingId),
         prisonApi.getPositiveCaseNotes(context, bookingId, dateThreeMonthsAgo, today),
         prisonApi.getNegativeCaseNotes(context, bookingId, dateThreeMonthsAgo, today),
         prisonApi.getAdjudicationsForBooking(context, bookingId),

--- a/backend/controllers/search/prisonerSearch.ts
+++ b/backend/controllers/search/prisonerSearch.ts
@@ -4,6 +4,7 @@ import { serviceUnavailableMessage } from '../../common-messages'
 import { User } from '../../middleware/currentUser'
 import { alertFlagLabels, profileAlertCodes } from '../../shared/alertFlagValues'
 import { putLastNameFirst, hasLength, formatLocation, toMap } from '../../utils'
+import type apis from '../../apis'
 import { Location } from '../../api/prisonApi'
 import { app } from '../../config'
 
@@ -61,6 +62,14 @@ export default ({
   telemetry,
   logError,
   systemOauthClient,
+}: {
+  paginationService
+  prisonApi
+  offenderSearchApi
+  incentivesApi: typeof apis.incentivesApi
+  telemetry
+  logError
+  systemOauthClient
 }) => {
   const index = async (req, res) => {
     const {
@@ -111,7 +120,7 @@ export default ({
       })
 
       const bookingIds = prisoners.map((prisoner) => prisoner.bookingId)
-      const [iepData] = await Promise.all([incentivesApi.getIepSummaryForBookingIds(localContext, bookingIds)])
+      const iepData = await incentivesApi.getIepSummaryForBookingIds(localContext, bookingIds)
       const iepBookingIdMap = toMap('bookingId', iepData)
 
       const locationOptions =

--- a/backend/tests/movementsService.test.ts
+++ b/backend/tests/movementsService.test.ts
@@ -195,7 +195,7 @@ describe('Movement service', () => {
         { offenderNo: 'G0000GG', bookingId: 1 },
         { offenderNo: 'G0001GG', bookingId: 2 },
       ])
-      incentivesApi.getIepSummaryForBookingIds.mockReturnValue([
+      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([
         { bookingId: 1, iepLevel: 'basic' },
         { bookingId: 2, iepLevel: 'standard' },
       ])
@@ -236,7 +236,7 @@ describe('Movement service', () => {
 
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getRecentMovements' does not exist on ty... Remove this comment to see the full error message
       prisonApi.getRecentMovements.mockReturnValue([])
-      incentivesApi.getIepSummaryForBookingIds.mockReturnValue([])
+      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([])
     })
 
     it('returns a empty array when there are no offenders in reception ', async () => {
@@ -335,7 +335,7 @@ describe('Movement service', () => {
     it('should request iep summary information for offenders in reception', async () => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getOffendersInReception' does not exist ... Remove this comment to see the full error message
       prisonApi.getOffendersInReception.mockReturnValue(offenders)
-      incentivesApi.getIepSummaryForBookingIds.mockReturnValue([
+      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([
         { ...offenders[0], iepLevel: 'basic' },
         { ...offenders[1], iepLevel: 'standard' },
       ])
@@ -555,7 +555,7 @@ describe('Movement service', () => {
           { offenderNo: 'G0000GG', bookingId: 1 },
           { offenderNo: 'G0001GG', bookingId: 2 },
         ])
-        incentivesApi.getIepSummaryForBookingIds.mockReturnValue([
+        incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([
           { bookingId: 1, iepLevel: 'basic' },
           { bookingId: 2, iepLevel: 'standard' },
         ])
@@ -754,7 +754,7 @@ describe('Movement service', () => {
           { offenderNo: 'G0000GG', bookingId: 1 },
           { offenderNo: 'G0001GG', bookingId: 2 },
         ])
-        incentivesApi.getIepSummaryForBookingIds.mockReturnValue([
+        incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([
           { bookingId: 1, iepLevel: 'basic' },
           { bookingId: 2, iepLevel: 'standard' },
         ])

--- a/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
@@ -1,4 +1,5 @@
 import type apis from '../apis'
+import type { IepSummaryForBooking, IepLevelChanged } from '../api/incentivesApi'
 import config from '../config'
 import prisonerChangeIncentiveLevelDetails from '../controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails'
 import { raiseAnalyticsEvent } from '../raiseAnalyticsEvent'
@@ -9,40 +10,43 @@ jest.mock('../raiseAnalyticsEvent', () => ({
 
 describe('Prisoner change incentive level details', () => {
   const offenderNo = 'ABC123'
-  const bookingId = '123'
+  const bookingId = 123
   const prisonApi = {}
   const incentivesApi = {} as jest.Mocked<typeof apis.incentivesApi>
 
-  const iepSummaryForBooking = {
-    bookingId: -1,
+  const iepSummaryForBooking: IepSummaryForBooking = {
+    bookingId,
     iepDate: '2017-08-15',
     iepTime: '2017-08-15T16:04:35',
     iepLevel: 'Standard',
     daysSinceReview: 625,
     iepDetails: [
       {
-        bookingId: -1,
+        bookingId,
         iepDate: '2017-08-15',
         iepTime: '2017-08-15T16:04:35',
         agencyId: 'LEI',
         iepLevel: 'Standard',
         userId: 'ITAG_USER',
+        comments: '3',
       },
       {
-        bookingId: -1,
+        bookingId,
         iepDate: '2017-08-10',
         iepTime: '2017-08-10T16:04:35',
         agencyId: 'HEI',
         iepLevel: 'Basic',
         userId: 'ITAG_USER',
+        comments: '2',
       },
       {
-        bookingId: -1,
+        bookingId,
         iepDate: '2017-08-07',
         iepTime: '2017-08-07T16:04:35',
         agencyId: 'HEI',
         iepLevel: 'Enhanced',
         userId: 'ITAG_USER',
+        comments: '1',
       },
     ],
   }
@@ -76,8 +80,8 @@ describe('Prisoner change incentive level details', () => {
       lastName: 'Smith',
       assignedLivingUnit: { description: '1-2-003' },
     })
-    incentivesApi.getIepSummaryForBooking = jest.fn().mockReturnValue(iepSummaryForBooking)
-    incentivesApi.getAgencyIepLevels = jest.fn().mockReturnValue(iepLevels)
+    incentivesApi.getIepSummaryForBooking = jest.fn().mockResolvedValue(iepSummaryForBooking)
+    incentivesApi.getAgencyIepLevels = jest.fn().mockResolvedValue(iepLevels)
     incentivesApi.changeIepLevel = jest.fn()
 
     // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{ prisonApi: {}; logError: any; ... Remove this comment to see the full error message
@@ -95,7 +99,7 @@ describe('Prisoner change incentive level details', () => {
         expect(incentivesApi.getAgencyIepLevels).toHaveBeenCalledWith(res.locals, 'MDI')
         expect(res.render).toHaveBeenCalledWith('prisonerProfile/prisonerChangeIncentiveLevelDetails.njk', {
           agencyId: 'MDI',
-          bookingId: '123',
+          bookingId,
           breadcrumbPrisonerName: 'Smith, John',
           formValues: {},
           iepLevel: 'Standard',
@@ -179,7 +183,7 @@ describe('Prisoner change incentive level details', () => {
       beforeEach(() => {
         config.apis.incentives.ui_url = 'http://incentives-url'
         jest.spyOn(Date, 'now').mockImplementation(() => 1664192096000) // 2022-09-26T12:34:56.000+01:00
-        incentivesApi.changeIepLevel.mockResolvedValue('All good')
+        incentivesApi.changeIepLevel.mockResolvedValue({} as unknown as IepLevelChanged) // response is ignored
       })
 
       it('should submit the appointment with the correct details and show confirmation', async () => {
@@ -214,7 +218,7 @@ describe('Prisoner change incentive level details', () => {
           'prisonerProfile/prisonerChangeIncentiveLevelConfirmation.njk',
           expect.objectContaining({
             agencyId: 'MDI',
-            bookingId: '123',
+            bookingId,
             breadcrumbPrisonerName: 'Smith, John',
             iepSummary: expect.objectContaining({
               iepLevel: 'Enhanced',
@@ -269,7 +273,7 @@ describe('Prisoner change incentive level details', () => {
         expect(incentivesApi.changeIepLevel).not.toHaveBeenCalled()
         expect(res.render).toHaveBeenCalledWith('prisonerProfile/prisonerChangeIncentiveLevelDetails.njk', {
           agencyId: 'MDI',
-          bookingId: '123',
+          bookingId,
           breadcrumbPrisonerName: 'Smith, John',
           errors: [
             {

--- a/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
@@ -1,5 +1,5 @@
 import type apis from '../apis'
-import type { IepSummaryForBooking, IepLevelChanged } from '../api/incentivesApi'
+import type { IepSummaryForBookingWithDetails, IepLevelChanged } from '../api/incentivesApi'
 import config from '../config'
 import prisonerChangeIncentiveLevelDetails from '../controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails'
 import { raiseAnalyticsEvent } from '../raiseAnalyticsEvent'
@@ -14,7 +14,7 @@ describe('Prisoner change incentive level details', () => {
   const prisonApi = {}
   const incentivesApi = {} as jest.Mocked<typeof apis.incentivesApi>
 
-  const iepSummaryForBooking: IepSummaryForBooking = {
+  const iepSummaryForBooking: IepSummaryForBookingWithDetails = {
     bookingId,
     iepDate: '2017-08-15',
     iepTime: '2017-08-15T16:04:35',

--- a/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
@@ -95,7 +95,7 @@ describe('Prisoner change incentive level details', () => {
 
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'getDetails' does not exist on type '{}'.
         expect(prisonApi.getDetails).toHaveBeenCalledWith(res.locals, offenderNo)
-        expect(incentivesApi.getIepSummaryForBooking).toHaveBeenCalledWith(res.locals, bookingId, true)
+        expect(incentivesApi.getIepSummaryForBooking).toHaveBeenCalledWith(res.locals, bookingId)
         expect(incentivesApi.getAgencyIepLevels).toHaveBeenCalledWith(res.locals, 'MDI')
         expect(res.render).toHaveBeenCalledWith('prisonerProfile/prisonerChangeIncentiveLevelDetails.njk', {
           agencyId: 'MDI',

--- a/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerChangeIncentiveLevelDetails.test.ts
@@ -128,7 +128,7 @@ describe('Prisoner change incentive level details', () => {
       })
 
       it('should indicate current incentive level ', async () => {
-        incentivesApi.getIepSummaryForBooking.mockReturnValue({
+        incentivesApi.getIepSummaryForBooking.mockResolvedValue({
           ...iepSummaryForBooking,
           iepLevel: 'Enhanced',
         })
@@ -179,11 +179,11 @@ describe('Prisoner change incentive level details', () => {
       beforeEach(() => {
         config.apis.incentives.ui_url = 'http://incentives-url'
         jest.spyOn(Date, 'now').mockImplementation(() => 1664192096000) // 2022-09-26T12:34:56.000+01:00
-        incentivesApi.changeIepLevel.mockReturnValue('All good')
+        incentivesApi.changeIepLevel.mockResolvedValue('All good')
       })
 
       it('should submit the appointment with the correct details and show confirmation', async () => {
-        incentivesApi.getIepSummaryForBooking.mockReturnValue({
+        incentivesApi.getIepSummaryForBooking.mockResolvedValue({
           ...iepSummaryForBooking,
           iepDate: '2022-09-26',
           iepTime: '2022-09-26T12:34:56',

--- a/backend/tests/prisonerIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerIncentiveLevelDetails.test.ts
@@ -1,5 +1,5 @@
 import type apis from '../apis'
-import type { IepSummaryForBooking } from '../api/incentivesApi'
+import type { IepSummaryForBookingWithDetails } from '../api/incentivesApi'
 import prisonerIncentiveLevelDetails from '../controllers/prisonerProfile/prisonerIncentiveLevelDetails'
 
 describe('Prisoner incentive level details', () => {
@@ -9,7 +9,7 @@ describe('Prisoner incentive level details', () => {
   const incentivesApi = {} as jest.Mocked<typeof apis.incentivesApi>
   const oauthApi = {}
 
-  const iepSummaryForBooking: IepSummaryForBooking = {
+  const iepSummaryForBooking: IepSummaryForBookingWithDetails = {
     bookingId,
     iepDate: '2017-08-15',
     iepTime: '2017-08-15T16:04:35',

--- a/backend/tests/prisonerIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerIncentiveLevelDetails.test.ts
@@ -1,15 +1,16 @@
 import type apis from '../apis'
+import type { IepSummaryForBooking } from '../api/incentivesApi'
 import prisonerIncentiveLevelDetails from '../controllers/prisonerProfile/prisonerIncentiveLevelDetails'
 
 describe('Prisoner incentive level details', () => {
   const offenderNo = 'ABC123'
-  const bookingId = '123'
+  const bookingId = 123
   const prisonApi = {}
   const incentivesApi = {} as jest.Mocked<typeof apis.incentivesApi>
   const oauthApi = {}
 
-  const iepSummaryForBooking = {
-    bookingId: -1,
+  const iepSummaryForBooking: IepSummaryForBooking = {
+    bookingId,
     iepDate: '2017-08-15',
     iepTime: '2017-08-15T16:04:35',
     iepLevel: 'Standard',
@@ -39,32 +40,35 @@ describe('Prisoner incentive level details', () => {
       .fn()
       .mockResolvedValue({ agencyId: 'MDI', bookingId, firstName: 'John', lastName: 'Smith' })
 
-    incentivesApi.getIepSummaryForBooking = jest.fn().mockReturnValue({
+    incentivesApi.getIepSummaryForBooking = jest.fn().mockResolvedValue({
       ...iepSummaryForBooking,
       iepDetails: [
         {
-          bookingId: -1,
+          bookingId,
           iepDate: '2017-08-15',
           iepTime: '2017-08-15T16:04:35',
           agencyId: 'LEI',
           iepLevel: 'Standard',
           userId: 'ITAG_USER',
+          comments: '3',
         },
         {
-          bookingId: -1,
+          bookingId,
           iepDate: '2017-08-10',
           iepTime: '2017-08-10T16:04:35',
           agencyId: 'HEI',
           iepLevel: 'Basic',
           userId: 'ITAG_USER',
+          comments: '2',
         },
         {
-          bookingId: -1,
+          bookingId,
           iepDate: '2017-08-07',
           iepTime: '2017-08-07T16:04:35',
           agencyId: 'HEI',
           iepLevel: 'Enhanced',
           userId: 'ITAG_USER',
+          comments: '1',
         },
       ],
     })
@@ -139,7 +143,7 @@ describe('Prisoner incentive level details', () => {
       results: [
         {
           agencyId: 'LEI',
-          bookingId: -1,
+          bookingId,
           formattedTime: '15 August 2017 - 16:04',
           iepDate: '2017-08-15',
           iepEstablishment: 'Leeds',
@@ -147,9 +151,10 @@ describe('Prisoner incentive level details', () => {
           iepStaffMember: 'Staff Member',
           iepTime: '2017-08-15T16:04:35',
           userId: 'ITAG_USER',
+          comments: '3',
         },
         {
-          bookingId: -1,
+          bookingId,
           iepDate: '2017-08-10',
           iepTime: '2017-08-10T16:04:35',
           formattedTime: '10 August 2017 - 16:04',
@@ -158,10 +163,11 @@ describe('Prisoner incentive level details', () => {
           agencyId: 'HEI',
           iepLevel: 'Basic',
           userId: 'ITAG_USER',
+          comments: '2',
         },
         {
           agencyId: 'HEI',
-          bookingId: -1,
+          bookingId,
           formattedTime: '7 August 2017 - 16:04',
           iepDate: '2017-08-07',
           iepEstablishment: 'Hewell',
@@ -169,6 +175,7 @@ describe('Prisoner incentive level details', () => {
           iepStaffMember: 'Staff Member',
           iepTime: '2017-08-07T16:04:35',
           userId: 'ITAG_USER',
+          comments: '1',
         },
       ],
       userCanUpdateIEP: false,
@@ -230,7 +237,7 @@ describe('Prisoner incentive level details', () => {
         },
         results: [
           {
-            bookingId: -1,
+            bookingId,
             iepDate: '2017-08-10',
             iepTime: '2017-08-10T16:04:35',
             formattedTime: '10 August 2017 - 16:04',
@@ -239,6 +246,7 @@ describe('Prisoner incentive level details', () => {
             agencyId: 'HEI',
             iepLevel: 'Basic',
             userId: 'ITAG_USER',
+            comments: '2',
           },
         ],
       })
@@ -259,7 +267,7 @@ describe('Prisoner incentive level details', () => {
         },
         results: [
           {
-            bookingId: -1,
+            bookingId,
             iepDate: '2017-08-10',
             iepTime: '2017-08-10T16:04:35',
             formattedTime: '10 August 2017 - 16:04',
@@ -268,6 +276,7 @@ describe('Prisoner incentive level details', () => {
             agencyId: 'HEI',
             iepLevel: 'Basic',
             userId: 'ITAG_USER',
+            comments: '2',
           },
         ],
       })
@@ -287,7 +296,7 @@ describe('Prisoner incentive level details', () => {
         },
         results: [
           {
-            bookingId: -1,
+            bookingId,
             iepDate: '2017-08-10',
             iepTime: '2017-08-10T16:04:35',
             formattedTime: '10 August 2017 - 16:04',
@@ -296,9 +305,10 @@ describe('Prisoner incentive level details', () => {
             agencyId: 'HEI',
             iepLevel: 'Basic',
             userId: 'ITAG_USER',
+            comments: '2',
           },
           {
-            bookingId: -1,
+            bookingId,
             iepDate: '2017-08-07',
             iepTime: '2017-08-07T16:04:35',
             formattedTime: '7 August 2017 - 16:04',
@@ -307,6 +317,7 @@ describe('Prisoner incentive level details', () => {
             agencyId: 'HEI',
             iepLevel: 'Enhanced',
             userId: 'ITAG_USER',
+            comments: '1',
           },
         ],
       })
@@ -334,7 +345,7 @@ describe('Prisoner incentive level details', () => {
         },
         results: [
           {
-            bookingId: -1,
+            bookingId,
             iepDate: '2017-08-10',
             iepTime: '2017-08-10T16:04:35',
             formattedTime: '10 August 2017 - 16:04',
@@ -343,6 +354,7 @@ describe('Prisoner incentive level details', () => {
             agencyId: 'HEI',
             iepLevel: 'Basic',
             userId: 'ITAG_USER',
+            comments: '2',
           },
         ],
       })
@@ -363,7 +375,7 @@ describe('Prisoner incentive level details', () => {
         },
         results: [
           {
-            bookingId: -1,
+            bookingId,
             iepDate: '2017-08-10',
             iepTime: '2017-08-10T16:04:35',
             formattedTime: '10 August 2017 - 16:04',
@@ -372,6 +384,7 @@ describe('Prisoner incentive level details', () => {
             agencyId: 'HEI',
             iepLevel: 'Basic',
             userId: 'ITAG_USER',
+            comments: '2',
           },
         ],
       })
@@ -381,7 +394,7 @@ describe('Prisoner incentive level details', () => {
   it('should return default message for no incentive level history', async () => {
     req.query = {}
 
-    incentivesApi.getIepSummaryForBooking = jest.fn().mockReturnValue(iepSummaryForBooking)
+    incentivesApi.getIepSummaryForBooking = jest.fn().mockResolvedValue(iepSummaryForBooking)
 
     await controller(req, res)
 
@@ -397,7 +410,7 @@ describe('Prisoner incentive level details', () => {
   it('should return default message when no incentive level history is returned for the supplied filters', async () => {
     req.query = { fromDate: '10/08/2017', toDate: '10/08/2017' }
 
-    incentivesApi.getIepSummaryForBooking = jest.fn().mockReturnValue(iepSummaryForBooking)
+    incentivesApi.getIepSummaryForBooking = jest.fn().mockResolvedValue(iepSummaryForBooking)
 
     await controller(req, res)
 

--- a/backend/tests/prisonerProfileService.test.ts
+++ b/backend/tests/prisonerProfileService.test.ts
@@ -90,7 +90,7 @@ describe('prisoner profile service', () => {
   })
   describe('prisoner profile data', () => {
     const offenderNo = 'ABC123'
-    const bookingId = '123'
+    const bookingId = 123
 
     const prisonerDetails = {
       activeAlertCount: 1,
@@ -172,7 +172,7 @@ describe('prisoner profile service', () => {
     beforeEach(() => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getDetails' does not exist on type '{}'.
       prisonApi.getDetails.mockReturnValue(prisonerDetails)
-      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([{ iepLevel: 'Standard' }])
+      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([{ bookingId, iepLevel: 'Standard' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getCaseNoteSummaryByTypes' does not exis... Remove this comment to see the full error message
       prisonApi.getCaseNoteSummaryByTypes.mockResolvedValue([{ latestCaseNote: '2020-04-07T14:04:25' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getStaffRoles' does not exist on type '{... Remove this comment to see the full error message
@@ -880,7 +880,7 @@ describe('prisoner profile service', () => {
 
   describe('prisoner with neurodiversity support', () => {
     const offenderNo = 'ABC123'
-    const bookingId = '123'
+    const bookingId = 123
 
     const neurodivergenceData = {
       prn: offenderNo,
@@ -974,7 +974,7 @@ describe('prisoner profile service', () => {
     beforeEach(() => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getDetails' does not exist on type '{}'.
       prisonApi.getDetails.mockReturnValue(prisonerDetails)
-      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([{ iepLevel: 'Standard' }])
+      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([{ bookingId, iepLevel: 'Standard' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getCaseNoteSummaryByTypes' does not exis... Remove this comment to see the full error message
       prisonApi.getCaseNoteSummaryByTypes.mockResolvedValue([{ latestCaseNote: '2020-04-07T14:04:25' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getStaffRoles' does not exist on type '{... Remove this comment to see the full error message
@@ -1010,7 +1010,7 @@ describe('prisoner profile service', () => {
   })
   describe('prisoner with no neurodiversity support', () => {
     const offenderNo = 'ABC123'
-    const bookingId = '123'
+    const bookingId = 123
 
     const neurodivergenceDataNoSupport = {
       prn: offenderNo,
@@ -1060,7 +1060,7 @@ describe('prisoner profile service', () => {
     beforeEach(() => {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getDetails' does not exist on type '{}'.
       prisonApi.getDetails.mockReturnValue(prisonerDetails)
-      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([{ iepLevel: 'Standard' }])
+      incentivesApi.getIepSummaryForBookingIds.mockResolvedValue([{ bookingId, iepLevel: 'Standard' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getCaseNoteSummaryByTypes' does not exis... Remove this comment to see the full error message
       prisonApi.getCaseNoteSummaryByTypes.mockResolvedValue([{ latestCaseNote: '2020-04-07T14:04:25' }])
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'getStaffRoles' does not exist on type '{... Remove this comment to see the full error message

--- a/backend/tests/prisonerQuickLook.test.ts
+++ b/backend/tests/prisonerQuickLook.test.ts
@@ -18,7 +18,7 @@ describe('prisoner profile quick look', () => {
     offenderNo,
     profileInformation: [{ type: 'NAT', resultValue: 'British' }],
   }
-  const bookingId = '123'
+  const bookingId = 123
   const iepSummaryForBooking = {
     bookingId,
     iepDate: '2017-08-15',
@@ -428,8 +428,7 @@ describe('prisoner profile quick look', () => {
         {
           user: { activeCaseLoad: { caseLoadId: 'MDI' } },
         },
-        bookingId,
-        false
+        bookingId
       )
       expect(prisonApi.getPositiveCaseNotes).toHaveBeenCalledWith(
         {

--- a/backend/utils.ts
+++ b/backend/utils.ts
@@ -85,7 +85,7 @@ export const mapToQueryString = (params: Record<never, never>): string =>
     })
     .join('&')
 
-export const toMap = (key: string, array: never[]): Map<any, any> =>
+export const toMap = <T = any, K extends keyof T = any>(key: K, array: T[]): Map<T[K], T> =>
   array.reduce((map, current) => {
     if (map.has(current[key]) === false) {
       map.set(current[key], current)

--- a/integration-tests/integration/prisonerProfile/prisonerChangeIncentiveLevelDetails.cy.js
+++ b/integration-tests/integration/prisonerProfile/prisonerChangeIncentiveLevelDetails.cy.js
@@ -7,32 +7,6 @@ const iepSummaryForBooking = {
   iepTime: '2017-08-15T16:04:35',
   iepLevel: 'Standard',
   daysSinceReview: 625,
-  iepDetails: [
-    {
-      bookingId: -1,
-      iepDate: '2017-08-15',
-      iepTime: '2017-08-15T16:04:35',
-      agencyId: 'LEI',
-      iepLevel: 'Standard',
-      userId: 'ITAG_USER',
-    },
-    {
-      bookingId: -1,
-      iepDate: '2017-08-10',
-      iepTime: '2017-08-10T16:04:35',
-      agencyId: 'MDI',
-      iepLevel: 'Basic',
-      userId: 'ITAG_USER',
-    },
-    {
-      bookingId: -1,
-      iepDate: '2017-08-07',
-      iepTime: '2017-08-07T16:04:35',
-      agencyId: 'MDI',
-      iepLevel: 'Enhanced',
-      userId: 'ITAG_USER_2',
-    },
-  ],
 }
 
 const iepLevels = [

--- a/integration-tests/integration/prisonerProfile/prisonerIncentiveLevelDetails.cy.js
+++ b/integration-tests/integration/prisonerProfile/prisonerIncentiveLevelDetails.cy.js
@@ -17,6 +17,7 @@ const iepSummaryResponse = {
       agencyId: 'LEI',
       iepLevel: 'Standard',
       userId: 'ITAG_USER',
+      comments: 'Comment 3',
     },
     {
       bookingId: -1,
@@ -25,6 +26,7 @@ const iepSummaryResponse = {
       agencyId: 'MDI',
       iepLevel: 'Basic',
       userId: 'ITAG_USER',
+      comments: 'Comment 2',
     },
     {
       bookingId: -1,
@@ -33,6 +35,7 @@ const iepSummaryResponse = {
       agencyId: 'MDI',
       iepLevel: 'Enhanced',
       userId: 'ITAG_USER_2',
+      comments: 'Comment 1',
     },
   ],
 }
@@ -149,19 +152,19 @@ context('Prisoner incentive level details', () => {
 
             expect($tableCells.get(0)).to.contain('15 August 2017 - 16:04')
             expect($tableCells.get(1)).to.contain('Standard')
-            expect($tableCells.get(2)).to.contain('Not entered')
+            expect($tableCells.get(2)).to.contain('Comment 3')
             expect($tableCells.get(3)).to.contain('Leeds')
             expect($tableCells.get(4)).to.contain('Staff Member')
 
             expect($tableCells.get(5)).to.contain('10 August 2017 - 16:04')
             expect($tableCells.get(6)).to.contain('Basic')
-            expect($tableCells.get(7)).to.contain('Not entered')
+            expect($tableCells.get(7)).to.contain('Comment 2')
             expect($tableCells.get(8)).to.contain('Moorland')
             expect($tableCells.get(9)).to.contain('Staff Member')
 
             expect($tableCells.get(10)).to.contain('7 August 2017 - 16:04')
             expect($tableCells.get(11)).to.contain('Enhanced')
-            expect($tableCells.get(12)).to.contain('Not entered')
+            expect($tableCells.get(12)).to.contain('Comment 1')
             expect($tableCells.get(13)).to.contain('Moorland')
             expect($tableCells.get(14)).to.contain('Another staff Member')
           })
@@ -185,7 +188,7 @@ context('Prisoner incentive level details', () => {
 
             expect($tableCells.get(0)).to.contain('10 August 2017 - 16:04')
             expect($tableCells.get(1)).to.contain('Basic')
-            expect($tableCells.get(2)).to.contain('Not entered')
+            expect($tableCells.get(2)).to.contain('Comment 2')
             expect($tableCells.get(3)).to.contain('Moorland')
             expect($tableCells.get(4)).to.contain('Staff Member')
           })


### PR DESCRIPTION
• Adds parameter and return types to incentives api object 
• Fixes some types in OAuth client api (e.g. POST methods _do_ in fact expect a body param)
• Fixes test mocks (a few used incorrect types, but test _logic_ all remains unchanged)
• Only functional code change is: IEP summary details aren't loaded on the incentive recording page (because they're unused)