### PR TITLE
INC-860 Fix DPS incentive level details page when history includes system generated reviews

### DIFF
--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -68,6 +68,15 @@ export const prisonApiFactory = (client) => {
   const get = (context, url, resultsLimit?, retryOverride?) =>
     client.get(context, url, { resultsLimit, retryOverride }).then(processResponse(context))
 
+  const map404ToNull = (error) => {
+    if (!error.response) throw error
+    if (!error.response.status) throw error
+    if (error.response.status !== 404) throw error
+    return null
+  }
+  const getWithHandle404 = (context, url, resultsLimit?, retryOverride?) =>
+    client.get(context, url, { resultsLimit, retryOverride }).then(processResponse(context)).catch(map404ToNull)
+
   const getWithCustomTimeout = (context, path, overrides) =>
     client.getWithCustomTimeout(context, path, overrides).then(processResponse(context))
 
@@ -148,7 +157,7 @@ export const prisonApiFactory = (client) => {
 
   const getAgencyDetails = (context, agencyId) => get(context, `/api/agencies/${agencyId}?activeOnly=false`)
 
-  const getStaffDetails = (context, staffId) => get(context, `/api/users/${staffId}`)
+  const getStaffDetails = (context, staffId) => getWithHandle404(context, `/api/users/${staffId}`)
 
   const getCourtEvents = (context, { agencyId, date, offenderNumbers }) =>
     post(context, `/api/schedules/${agencyId}/courtEvents?date=${date}`, offenderNumbers)

--- a/backend/controllers/prisonerProfile/prisonerIncentiveLevelDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerIncentiveLevelDetails.ts
@@ -39,6 +39,10 @@ const filterData = (data: HistoryDetail[], fields: HistoryFilters): HistoryDetai
   return filteredResults
 }
 
+function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
+  return value !== null && value !== undefined
+}
+
 export default ({
     prisonApi,
     incentivesApi,
@@ -77,9 +81,14 @@ export default ({
       const uniqueAgencyIds = Array.from(new Set(iepSummary.iepDetails.map((details) => details.agencyId)))
       const levels = Array.from(new Set(iepSummary.iepDetails.map((details) => details.iepLevel))).sort()
 
-      const users = await Promise.all(
-        uniqueUserIds.filter((userId) => Boolean(userId)).map((userId) => prisonApi.getStaffDetails(res.locals, userId))
-      )
+      // Only get users that map to a user in the prison staff table
+      const users = (
+        await Promise.all(
+          uniqueUserIds
+            .filter((userId) => Boolean(userId))
+            .map((userId) => prisonApi.getStaffDetails(res.locals, userId))
+        )
+      ).filter(notEmpty)
 
       const establishments = await Promise.all(
         uniqueAgencyIds.filter((id) => Boolean(id)).map((id) => prisonApi.getAgencyDetails(res.locals, id))

--- a/backend/tests/prisonerIncentiveLevelDetails.test.ts
+++ b/backend/tests/prisonerIncentiveLevelDetails.test.ts
@@ -50,7 +50,7 @@ describe('Prisoner incentive level details', () => {
           iepTime: '2017-08-15T16:04:35',
           agencyId: 'LEI',
           iepLevel: 'Standard',
-          userId: 'ITAG_USER',
+          userId: 'INCENTIVES-API',
           comments: '3',
         },
         {
@@ -149,9 +149,9 @@ describe('Prisoner incentive level details', () => {
           iepDate: '2017-08-15',
           iepEstablishment: 'Leeds',
           iepLevel: 'Standard',
-          iepStaffMember: 'Staff Member',
+          iepStaffMember: undefined,
           iepTime: '2017-08-15T16:04:35',
-          userId: 'ITAG_USER',
+          userId: 'INCENTIVES-API',
           comments: '3',
         },
         {

--- a/integration-tests/integration/prisonerProfile/prisonerIncentiveLevelDetails.cy.js
+++ b/integration-tests/integration/prisonerProfile/prisonerIncentiveLevelDetails.cy.js
@@ -17,7 +17,7 @@ const iepSummaryResponse = {
       iepTime: '2017-08-15T16:04:35',
       agencyId: 'LEI',
       iepLevel: 'Standard',
-      userId: 'ITAG_USER',
+      userId: 'INCENTIVES-API',
       comments: 'Comment 3',
     },
     {
@@ -154,7 +154,7 @@ context('Prisoner incentive level details', () => {
             expect($tableCells.get(1)).to.contain('Standard')
             expect($tableCells.get(2)).to.contain('Comment 3')
             expect($tableCells.get(3)).to.contain('Leeds')
-            expect($tableCells.get(4)).to.contain('Staff Member')
+            expect($tableCells.get(4)).to.contain('Not entered')
 
             expect($tableCells.get(5)).to.contain('10 August 2017 - 16:04')
             expect($tableCells.get(6)).to.contain('Basic')


### PR DESCRIPTION
For unmatched records we now visually get "not entered" which we can iterate on by stops the screen crashing
