### PR TITLE
NN-4481: alerts add visor

### DIFF
--- a/backend/shared/alertFlagValues.ts
+++ b/backend/shared/alertFlagValues.ts
@@ -98,6 +98,7 @@ export const alertFlagLabels = [
   { alertCodes: ['URS'], classes: 'alert-status alert-status--refusing-to-shield', label: 'Refusing to shield' },
   { alertCodes: ['RKS'], classes: 'alert-status alert-status--risk-to-known-adults', label: 'Risk to known adults' },
   { alertCodes: ['VIP'], classes: 'alert-status alert-status--isolated-prisoner', label: 'Isolated' },
+  { alertCodes: ['PVN'], classes: 'alert-status alert-status--multicase alert-status--visor', label: 'ViSOR' },
 ].sort((a, b) => a.label.localeCompare(b.label))
 
 export const cellMoveAlertCodes = [
@@ -120,6 +121,7 @@ export const cellMoveAlertCodes = [
   'HA',
   'HA1',
   'RTP',
+  'PVN',
 ]
 
 export const profileAlertCodes = [
@@ -150,6 +152,7 @@ export const profileAlertCodes = [
   'UPIU',
   'USU',
   'URS',
+  'PVN',
 ]
 
 export type AlertLabelFlag = {

--- a/backend/tests/establishmentRoll/inReceptionController.test.ts
+++ b/backend/tests/establishmentRoll/inReceptionController.test.ts
@@ -76,6 +76,10 @@ describe('In reception controller', () => {
               label: 'Care experienced',
             },
             {
+              classes: 'alert-status alert-status--multicase alert-status--visor',
+              label: 'ViSOR',
+            },
+            {
               classes: 'alert-status alert-status--acct',
               label: 'ACCT open',
             },

--- a/backend/tests/prisonerSearch.test.ts
+++ b/backend/tests/prisonerSearch.test.ts
@@ -164,6 +164,7 @@ describe('Prisoner search', () => {
             { checked: false, text: 'Staff assaulter', value: ['XSA'] },
             { checked: false, text: 'TACT', value: ['XTACT'] },
             { checked: false, text: 'Veteran', value: ['F1'] },
+            { checked: false, text: 'ViSOR', value: ['PVN'] },
           ],
           locationOptions: [
             { text: 'Moorland (HMP & YOI)', value: 'MDI' },
@@ -569,6 +570,7 @@ describe('Prisoner search', () => {
             { checked: false, text: 'Staff assaulter', value: ['XSA'] },
             { checked: false, text: 'TACT', value: ['XTACT'] },
             { checked: false, text: 'Veteran', value: ['F1'] },
+            { checked: false, text: 'ViSOR', value: ['PVN'] },
           ],
           locationOptions: [
             { text: 'Moorland (HMP & YOI)', value: 'MDI' },

--- a/sass/components/_alert-flags.scss
+++ b/sass/components/_alert-flags.scss
@@ -202,6 +202,18 @@
     color: #00753F;
     border-color: #00753F;
   }
+
+  &--visor {
+    color: #003078;
+    border-color: #003078;
+  }
+}
+
+.alert-status--multicase {
+  @media screen {
+    text-transform: none;
+    min-height: 30px;
+  }
 }
 
 .cat-a-status {


### PR DESCRIPTION
**Add VISOR alert to the list of DPS alerts**

Acceptance Criteria
• Unsaved changes

The alert should be visible in the 

Global Prisoner Search – for example [HMPPS Digital Services - Sign in](https://digital-dev.prison.service.justice.gov.uk/prisoner-search?keywords=&location=MDI)

Prisoner Profile –  for example [HMPPS Digital Services - Sign in](https://digital-dev.prison.service.justice.gov.uk/prisoner/G6123VU) 

ViSOR Nominal (PVN) is an existing alert that can be added to a prisoner profile. The type of alert is ‘MAPPP Case' and the alert is called 'ViSOR nominal’.

The alert label will appear with the other labels at the top of the Prisoner profile, when the alert has been added to a prisoner’s record.

The label should read ViSOR in capital letters (lower case i) and be #003078 coloured text with the same colour border.

The label should appear in alphabetical order like the existing labels.