### PR TITLE
Stop calling incentives-api when prisoner search finds no results

### DIFF
--- a/backend/controllers/search/prisonerSearch.ts
+++ b/backend/controllers/search/prisonerSearch.ts
@@ -1,4 +1,5 @@
 import qs from 'querystring'
+import type { IepSummaryForBookingId } from '../../api/incentivesApi'
 import { PrisonerInPrisonSearchResult } from '../../api/offenderSearchApi'
 import { serviceUnavailableMessage } from '../../common-messages'
 import { User } from '../../middleware/currentUser'
@@ -119,9 +120,12 @@ export default ({
         username,
       })
 
-      const bookingIds = prisoners.map((prisoner) => prisoner.bookingId)
-      const iepData = await incentivesApi.getIepSummaryForBookingIds(localContext, bookingIds)
-      const iepBookingIdMap = toMap('bookingId', iepData)
+      let iepBookingIdMap = new Map<number, IepSummaryForBookingId>()
+      if (prisoners.length) {
+        const bookingIds = prisoners.map((prisoner) => prisoner.bookingId)
+        const iepData = await incentivesApi.getIepSummaryForBookingIds(localContext, bookingIds)
+        iepBookingIdMap = toMap('bookingId', iepData)
+      }
 
       const locationOptions =
         locations && locations.map((option) => ({ value: option.locationPrefix, text: option.description }))

--- a/backend/tests/prisonerSearch.test.ts
+++ b/backend/tests/prisonerSearch.test.ts
@@ -370,6 +370,18 @@ describe('Prisoner search', () => {
       })
     })
 
+    describe('when no inmates returned', () => {
+      beforeEach(() => {
+        res.locals.responseHeaders['total-records'] = 0
+        prisonApi.getInmates = jest.fn().mockReturnValue([])
+      })
+
+      it('should should not call incentives api', async () => {
+        await controller.index(req, res)
+        expect(incentivesApi.getIepSummaryForBookingIds).not.toHaveBeenCalled()
+      })
+    })
+
     it('should render template with correct urls containing view type and printed values', async () => {
       req.baseUrl = '/prisoner-search'
       req.query = {
@@ -778,6 +790,18 @@ describe('Prisoner search', () => {
             caseLoadId: 'MDI',
           },
         })
+      })
+    })
+
+    describe('when no inmates returned', () => {
+      beforeEach(() => {
+        res.locals.responseHeaders['total-records'] = 0
+        prisonApi.getInmates = jest.fn().mockReturnValue([])
+      })
+
+      it('should should not call incentives api', async () => {
+        await controller.index(req, res)
+        expect(incentivesApi.getIepSummaryForBookingIds).not.toHaveBeenCalled()
       })
     })
 


### PR DESCRIPTION
…because it's started to enforce validation (submitted booking ids cannot be an empty list)