### PR TITLE
NN-4458 clear backlink from session

### DIFF
--- a/backend/controllers/globalSearch.ts
+++ b/backend/controllers/globalSearch.ts
@@ -64,6 +64,7 @@ export default ({ paginationService, offenderSearchApi, oauthApi, telemetry }) =
   }
   const prisonerBooked = (prisoner) => prisoner.latestBookingId > 0
   const resultsPage = async (req, res) => {
+    delete req.session.userBackLink
     let prisonerResults = []
     const {
       user: { activeCaseLoad },


### PR DESCRIPTION
**Bug**
Backlink that is stored in the session in the local establishment search isn't cleared out when searching using global search. 

**Solution**
Clear the saved backlink when using global search.