### PR TITLE
INC-945: Interrupt flow when adding Incentive Level Review case note

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -117,6 +117,7 @@ export const apis = {
   incentives: {
     ui_url: process.env.INCENTIVES_URL,
     excludedCaseloads: process.env.INCENTIVES_EXCLUDED_CASELOADS || '',
+    privateBetaEnabledPrisons: process.env.INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS || '',
   },
   calculateReleaseDates: {
     ui_url: process.env.CALCULATE_RELEASE_DATES_URL,

--- a/backend/controllers/caseNote.ts
+++ b/backend/controllers/caseNote.ts
@@ -269,6 +269,10 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
 
     if (errors.length > 0) return stashStateAndRedirectToAddCaseNote(req, res, caseNote, offenderNo, errors)
 
+    if (type === 'REPORTS' && subType === 'REP_IEP') {
+      return res.redirect(`${getOffenderUrl(offenderNo)}/add-case-note/record-incentive-level`)
+    }
+
     return res.redirect(`${getOffenderUrl(offenderNo)}/case-notes`)
   }
 

--- a/backend/controllers/caseNote.ts
+++ b/backend/controllers/caseNote.ts
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import nunjucks from 'nunjucks'
+import config from '../config'
 import { properCaseName } from '../utils'
 import getContext from './prisonerProfile/prisonerProfileContext'
 
@@ -229,6 +230,7 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
   const post = async (req, res) => {
     const { offenderNo } = req.params
     const { type, subType, text, date, hours, minutes } = req.body
+    const { activeCaseLoadId } = req.session.userDetails
     const errors = validate(type, subType, text, date, hours, minutes)
 
     const context = await getContextWithRoles(offenderNo, res, req, oauthApi, systemOauthClient, restrictedPatientApi)
@@ -269,7 +271,11 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
 
     if (errors.length > 0) return stashStateAndRedirectToAddCaseNote(req, res, caseNote, offenderNo, errors)
 
-    if (type === 'REPORTS' && subType === 'REP_IEP') {
+    if (
+      type === 'REPORTS' &&
+      subType === 'REP_IEP' &&
+      config.apis.incentives.privateBetaEnabledPrisons.split(',').includes(activeCaseLoadId)
+    ) {
       return res.redirect(`${getOffenderUrl(offenderNo)}/add-case-note/record-incentive-level`)
     }
 

--- a/backend/controllers/caseNote.ts
+++ b/backend/controllers/caseNote.ts
@@ -324,7 +324,21 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
     return res.redirect(`${getOffenderUrl(offenderNo)}/case-notes`)
   }
 
-  return { index, post, areYouSure, confirm }
+  const recordIncentiveLevelInterruption = async (req, res) => {
+    const { offenderNo } = req.params
+    const context = await getContextWithRoles(offenderNo, res, req, oauthApi, systemOauthClient, restrictedPatientApi)
+    const offenderDetails = await getOffenderDetails(context, offenderNo)
+
+    return res.render('caseNotes/recordIncentiveLevelInterruption.njk', {
+      title: 'Record incentive level',
+      breadcrumbText: 'Record incentive level',
+      offenderDetails,
+      caseNotesUrl: `${offenderDetails.profileUrl}/case-notes`,
+      recordIncentiveLevelUrl: `${offenderDetails.profileUrl}/incentive-level-details/change-incentive-level`,
+    })
+  }
+
+  return { index, post, areYouSure, confirm, recordIncentiveLevelInterruption }
 }
 
 export const behaviourPrompts = {

--- a/backend/routes/caseNoteCreationRouter.ts
+++ b/backend/routes/caseNoteCreationRouter.ts
@@ -4,7 +4,7 @@ import { caseNoteFactory } from '../controllers/caseNote'
 const router = express.Router({ mergeParams: true })
 
 const controller = ({ prisonApi, caseNotesApi, oauthApi, systemOauthClient, restrictedPatientApi }) => {
-  const { index, post, areYouSure, confirm } = caseNoteFactory({
+  const { index, post, areYouSure, confirm, recordIncentiveLevelInterruption } = caseNoteFactory({
     prisonApi,
     caseNotesApi,
     oauthApi,
@@ -16,6 +16,7 @@ const controller = ({ prisonApi, caseNotesApi, oauthApi, systemOauthClient, rest
   router.post('/', post)
   router.get('/confirm', areYouSure)
   router.post('/confirm', confirm)
+  router.get('/record-incentive-level', recordIncentiveLevelInterruption)
 
   return router
 }

--- a/backend/tests/caseNote.test.ts
+++ b/backend/tests/caseNote.test.ts
@@ -10,7 +10,7 @@ const restrictedPatientApi = {}
 const systemOauthClient = {}
 const oauthApi = {}
 
-const { index, post, areYouSure, confirm } = caseNoteCtrl.caseNoteFactory({
+const { index, post, areYouSure, confirm, recordIncentiveLevelInterruption } = caseNoteCtrl.caseNoteFactory({
   prisonApi,
   caseNotesApi,
   oauthApi,
@@ -615,6 +615,27 @@ describe('case note management', () => {
         { href: '#confirmed', text: 'Select yes if this information is appropriate to share' },
       ])
       expect(res.redirect).toBeCalledWith('/prisoner/ABC123/add-case-note/confirm')
+    })
+  })
+
+  describe('recordIncentiveLevelInterruption()', () => {
+    it('should render the interruption page', async () => {
+      const req = { ...mockCreateReq, params: { offenderNo } }
+
+      await recordIncentiveLevelInterruption(req, res)
+
+      expect(res.render).toBeCalledWith(
+        'caseNotes/recordIncentiveLevelInterruption.njk',
+        expect.objectContaining({
+          offenderDetails: {
+            name: 'Test User',
+            offenderNo: 'ABC123',
+            profileUrl: '/prisoner/ABC123',
+          },
+          caseNotesUrl: '/prisoner/ABC123/case-notes',
+          recordIncentiveLevelUrl: '/prisoner/ABC123/incentive-level-details/change-incentive-level',
+        })
+      )
     })
   })
 })

--- a/backend/tests/caseNote.test.ts
+++ b/backend/tests/caseNote.test.ts
@@ -25,11 +25,13 @@ jest.mock('../logError', () => ({
 describe('case note management', () => {
   let res
 
+  const mockSession = { userDetails: { activeCaseLoadId: 'LEI', authSource: 'nomis' } }
   const mockCreateReq = {
     flash: jest.fn().mockReturnValue([]),
     originalUrl: '/add-case-note/',
     get: jest.fn(),
     body: {},
+    session: { ...mockSession },
   }
   const getDetailsResponse = {
     bookingId: 1234,
@@ -531,14 +533,14 @@ describe('case note management', () => {
           ...mockCreateReq,
           params: { offenderNo },
           body: caseNote,
-          session: {},
+          session: { ...mockSession },
         }
 
         await post(req, res)
 
         expect(caseNotesApi.addCaseNote).not.toHaveBeenCalled()
         expect(res.redirect).toBeCalledWith('/prisoner/ABC123/add-case-note/confirm')
-        expect(req.session).toEqual({ draftCaseNote: { ...caseNote, offenderNo } })
+        expect(req.session).toEqual(expect.objectContaining({ draftCaseNote: { ...caseNote, offenderNo } }))
       })
     })
   })
@@ -567,7 +569,7 @@ describe('case note management', () => {
       const req = {
         ...mockCreateReq,
         params: { offenderNo },
-        session: { draftCaseNote: { text: 'hello', date: '20/01/2020', hours: '23', minutes: '10' } },
+        session: { ...mockSession, draftCaseNote: { text: 'hello', date: '20/01/2020', hours: '23', minutes: '10' } },
         body: { confirmed: 'Yes' },
       }
 
@@ -587,7 +589,7 @@ describe('case note management', () => {
       const req = {
         ...mockCreateReq,
         params: { offenderNo },
-        session: { draftCaseNote: { text: 'hello', date: '20/01/2020', hours: '23', minutes: '10' } },
+        session: { ...mockSession, draftCaseNote: { text: 'hello', date: '20/01/2020', hours: '23', minutes: '10' } },
         body: { confirmed: 'Yes' },
       }
       const error400 = makeError('response', {
@@ -623,7 +625,7 @@ describe('case note management', () => {
       const req = {
         ...mockCreateReq,
         params: { offenderNo },
-        session: { draftCaseNote: { text: 'hello' } },
+        session: { ...mockSession, draftCaseNote: { text: 'hello' } },
         body: { confirmed: 'No' },
       }
 
@@ -640,7 +642,7 @@ describe('case note management', () => {
       const req = {
         ...mockCreateReq,
         params: { offenderNo },
-        session: { draftCaseNote: { text: 'hello' } },
+        session: { ...mockSession, draftCaseNote: { text: 'hello' } },
       }
 
       await confirm(req, res)

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,9 +4,9 @@ generic-service:
   replicaCount: 2
 
   ingress:
-   host: digital-dev.prison.service.justice.gov.uk 
+   host: digital-dev.prison.service.justice.gov.uk
 
-  allowlist: false 
+  allowlist: false
 
   env:
    PRISON_STAFF_HUB_UI_URL: https://digital-dev.prison.service.justice.gov.uk/
@@ -27,6 +27,7 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui-dev.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-dev.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
+   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "LEI,MDI"
    TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://dev.moic.service.justice.gov.uk/

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,6 +24,7 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
+   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "LEI,MDI"
    TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://preprod.moic.service.justice.gov.uk
@@ -109,4 +110,4 @@ generic-service:
    moj-official-ark-c-expo-e: "51.149.249.0/29"
    moj-official-ark-c-vodafone: "194.33.248.0/29"
    moj-official-ark-f-vodafone: "194.33.249.0/29"
-   moj-official-ark-f-expo-e: "51.149.249.32/29" 
+   moj-official-ark-f-expo-e: "51.149.249.32/29"

--- a/sass/application.scss
+++ b/sass/application.scss
@@ -75,6 +75,18 @@ $govuk-font-family-print: 'GDS Transport';
   }
 }
 
+.interruption-panel {
+  @extend .govuk-panel;
+
+  text-align: left;
+  background-color: govuk-colour('blue');
+  color: govuk-colour('white');
+
+  .govuk-heading-l, .govuk-body {
+    color: govuk-colour('white');
+  }
+}
+
 .suspended {
   color: #df3034;
   font-weight: 700;

--- a/views/caseNotes/recordIncentiveLevelInterruption.njk
+++ b/views/caseNotes/recordIncentiveLevelInterruption.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "../partials/layout.njk" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: offenderDetails.name,
+        href: offenderDetails.profileUrl
+      },
+      {
+        text: breadcrumbText
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="interruption-panel govuk-!-margin-bottom-9">
+        <h1 class="govuk-heading-l">
+          If you are recording incentive level details, you need to use the ‘record an incentive level’ page.
+        </h1>
+        <p class="govuk-body">
+          {{ govukButton({ text: "Record incentive level", href: recordIncentiveLevelUrl, classes: "govuk-button--secondary" }) }}
+          <br />
+          <a href="{{ caseNotesUrl }}" class="govuk-link govuk-link--inverse">Return to prisoner profile</a>
+        </p>
+      </div>
+
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
…so that users know they must also record an incentive level review in another part of DPS. Amending a case note does not require this reminder.

This will be conditionally enabled for a few prisons for private beta rollout. For now, it’s on in `dev` and `preprod` for Leeds and Moorland.