### PR TITLE
SDI-509 House block appended with `dash`

### DIFF
--- a/backend/controllers/search/prisonerSearch.ts
+++ b/backend/controllers/search/prisonerSearch.ts
@@ -220,7 +220,7 @@ export default ({
         ? offenderSearchApi.establishmentSearch(searchContext, prisonId, {
             term: keywords,
             alerts: selectedAlerts,
-            cellLocationPrefix: internalLocation,
+            cellLocationPrefix: internalLocation && `${internalLocation}-`,
           })
         : Promise.resolve([])
 

--- a/backend/tests/prisonerSearch.test.ts
+++ b/backend/tests/prisonerSearch.test.ts
@@ -131,18 +131,18 @@ describe('Prisoner search', () => {
       expect(offenderSearchApi.establishmentSearch).toHaveBeenCalledWith(expect.anything(), 'BXI', {})
     })
 
-    it('should request with parsed location when supplied in query', async () => {
-      req.query.location = 'BXI-B-1-0'
+    it('should request with parsed location when supplied in query with dash to indicate partial match', async () => {
+      req.query.location = 'BXI-B'
 
       await controller.index(req, res)
 
       expect(offenderSearchApi.establishmentSearch).toHaveBeenCalledWith(expect.anything(), 'BXI', {
-        cellLocationPrefix: 'BXI-B-1-0',
+        cellLocationPrefix: 'BXI-B-',
       })
     })
 
     it('should request with full location as cell prefix when supplied in query', async () => {
-      req.query.location = 'BXI-B-1-0'
+      req.query.location = 'BXI-B'
 
       await controller.index(req, res)
 


### PR DESCRIPTION
This ensures search for block `C` doesn't bring back prisoner in block `Cswap` 