### PR TITLE
INC-953: Enable case note entry interruption for private beta prison groups 1 & 2 of ‘Manage Incentives’

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -27,7 +27,7 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui-dev.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-dev.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "MDI,WII"
+   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "MDI,BAI,CFI,CWI,DAI,EXI,HOI,WCI,WHI,WII,WNI"
    TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://dev.moic.service.justice.gov.uk/

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,7 +24,7 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "MDI,WII"
+   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "MDI,BAI,CFI,CWI,DAI,EXI,HOI,WCI,WHI,WII,WNI"
    TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://preprod.moic.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,7 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "WII"
+   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "BAI,CFI,CWI,DAI,EXI,HOI,WCI,WHI,WII,WNI"
    TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://moic.service.justice.gov.uk/


### PR DESCRIPTION
See also: [hmpps-incentives-ui#354](https://github.com/ministryofjustice/hmpps-incentives-ui/pull/354)
Should be deployed on 5 Jan.