### PR TITLE
ESWE-420_neurodiversity_enable_moorland

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -40,7 +40,7 @@ generic-service:
    SUPPORT_URL: https://support-dev.hmpps.service.justice.gov.uk/
    ESWE_ENABLED: false
    NEURODIVERSITY_ENABLED_USERNAMES: ""
-   NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
+   NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI,MDI"
    CURIOUS_URL: https://testservices.sequation.net/sequation-virtual-campus2-api/
    SYSTEM_PHASE: DEV
    BVL_URL: https://book-video-link-dev.prison.service.justice.gov.uk

--- a/integration-tests/integration/prisonerProfile/prisonerPersonal.cy.js
+++ b/integration-tests/integration/prisonerProfile/prisonerPersonal.cy.js
@@ -268,7 +268,9 @@ context('Prisoner personal', () => {
     context('Disabilities and adjustments section', () => {
       it('Should show correct missing content text', () => {
         cy.get('[data-test="neurodiversity-summary"]').then(($section) => {
-          expect($section).to.contain.text('John Smith has no recorded neurodiversity needs.')
+          expect($section).to.contain.text(
+            'DPS currently includes neurodiversity information recorded for prisoners in HMPs Bristol, Lincoln, New Hall and Swaleside.'
+          )
         })
         cy.get('[data-test="care-needs-summary"]').then(($section) => {
           expect($section).to.contain.text('None')
@@ -1390,7 +1392,9 @@ context('Prisoner personal', () => {
 
       it('Should list no neurodivergence info for learner', () => {
         cy.get('[data-test="neurodiversity-summary"]').then(($section) => {
-          expect($section).to.contain.text('John Smith has no recorded neurodiversity needs.')
+          expect($section).to.contain.text(
+            'DPS currently includes neurodiversity information recorded for prisoners in HMPs Bristol, Lincoln, New Hall and Swaleside.'
+          )
         })
       })
     })

--- a/views/prisonerProfile/prisonerPersonal/partials/neurodiversities.njk
+++ b/views/prisonerProfile/prisonerPersonal/partials/neurodiversities.njk
@@ -12,7 +12,8 @@
     {% endfor %}
 
     {% if not neurodiversityInfo.length %}
-    <p class="govuk-body">{{ offenderName }} has no recorded neurodiversity needs.</p>
+        <p class="govuk-body">DPS currently includes neurodiversity information recorded for prisoners in HMPs Bristol, Lincoln, New Hall and Swaleside.</p>
+        <p class="govuk-body">To check for neurodiversity information for someone in another establishment, contact the education team in that establishment.</p>
     {% endif %}
 {% else %}
     <p class="govuk-body" data-test="neurodiversity-errorMessage">{{ errorMessage }}</p>


### PR DESCRIPTION
Add Moorland to the list of sites allowed to view neurodiversity data.
Update message displayed when no neurodiversity data found.
Reviewers
@natclamp-moj