### PR TITLE
INC-1103: Removed 'Date of last review' from Incentive details page

### DIFF
--- a/views/prisonerProfile/prisonerIncentiveLevelDetails.njk
+++ b/views/prisonerProfile/prisonerIncentiveLevelDetails.njk
@@ -45,10 +45,6 @@
             <p class="govuk-body" data-test="current-iep">{{ currentIepLevel }}</p>
         </div>
         <div class="horizontal-information__item">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Date of last review</h3>
-            <p class="govuk-body" data-test="last-review-date">{{ currentIepDate }}</p>
-        </div>
-        <div class="horizontal-information__item">
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Date of next review</h3>
             <p class="govuk-body" data-test="next-review-date">
                 {{ nextReviewDate }}


### PR DESCRIPTION
This date is currently not accurate. This is the date of the last Incentive record which is not necessarily an Incentive review (it could be a transfer for example).