### PR TITLE
INC-1151: March 20th: More prisons to private beta

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,7 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "BAI,CFI,CWI,DAI,EXI,GHI,GMI,HOI,SWI,UKI,WCI,WDI,WHI,WII,WNI"
+   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "BAI,BFI,BLI,BRI,CDI,CFI,CWI,DAI,EXI,GHI,GMI,HBI,HOI,HPI,HVI,KMI,LCI,LFI,LII,LTI,LYI,MHI,MTI,NSI,NWI,ONI,PDI,PNI,SWI,UKI,VEI,WCI,WDI,WHI,WII,WLI,WMI,WNI,WTI"
    TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://moic.service.justice.gov.uk/


### PR DESCRIPTION
**NOTE**: This can be merged/deployed on Monday.

This is the list of new private beta prisons:

| ID  | Prison name     |
|-----|-----------------|
| BFI | Bedford         |
| BLI | Bristol         |
| BRI | Bure            |
| CDI | Chelmsford      |
| HBI | Hollesley Bay   |
| HPI | Highpoint       |
| HVI | Haverigg        |
| KMI | Kirkham         |
| LCI | Leicester       |
| LFI | Lancaster Farms |
| LII | Lincoln         |
| LTI | Littlehey       |
| LYI | Leyhill         |
| MHI | Morton Hall     |
| MTI | The Mount       |
| NSI | North Sea Camp  |
| NWI | Norwich         |
| ONI | Onley           |
| PDI | Portland        |
| PNI | Preston         |
| VEI | The Verne       |
| WLI | Wayland         |
| WMI | Wymott          |
| WTI | Whatton         |