### PR TITLE
INC-1164: April 3rd: National rollout of interruption screen

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -119,7 +119,6 @@ export const apis = {
   incentives: {
     ui_url: process.env.INCENTIVES_URL,
     excludedCaseloads: process.env.INCENTIVES_EXCLUDED_CASELOADS || '',
-    privateBetaEnabledPrisons: process.env.INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS || '',
   },
   calculateReleaseDates: {
     ui_url: process.env.CALCULATE_RELEASE_DATES_URL,

--- a/backend/controllers/caseNote.ts
+++ b/backend/controllers/caseNote.ts
@@ -271,11 +271,7 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
 
     if (errors.length > 0) return stashStateAndRedirectToAddCaseNote(req, res, caseNote, offenderNo, errors)
 
-    if (
-      type === 'REPORTS' &&
-      subType === 'REP_IEP' &&
-      config.apis.incentives.privateBetaEnabledPrisons.split(',').includes(activeCaseLoadId)
-    ) {
+    if (type === 'REPORTS' && subType === 'REP_IEP') {
       return res.redirect(`${getOffenderUrl(offenderNo)}/add-case-note/record-incentive-level`)
     }
 

--- a/backend/tests/caseNote.test.ts
+++ b/backend/tests/caseNote.test.ts
@@ -496,14 +496,6 @@ describe('case note management', () => {
       })
 
       describe('if incentive level review posted', () => {
-        let privateBetaEnabledPrisons
-        beforeAll(() => {
-          privateBetaEnabledPrisons = config.apis.incentives.privateBetaEnabledPrisons
-        })
-        afterAll(() => {
-          config.apis.incentives.privateBetaEnabledPrisons = privateBetaEnabledPrisons
-        })
-
         const req = {
           ...mockCreateReq,
           params: { offenderNo },
@@ -526,22 +518,11 @@ describe('case note management', () => {
             occurrenceDateTime: expect.any(String),
           })
 
-        it('should submit and interrupt journey for private beta prisons', async () => {
-          config.apis.incentives.privateBetaEnabledPrisons = 'BXI,LEI'
-
+        it('should submit and interrupt journey', async () => {
           await post(req, res)
 
           expectCaseNoteAdded()
           expect(res.redirect).toBeCalledWith('/prisoner/ABC123/add-case-note/record-incentive-level')
-        })
-
-        it('should submit and not interrupt journey for other prisons', async () => {
-          config.apis.incentives.privateBetaEnabledPrisons = 'MDI,WRI'
-
-          await post(req, res)
-
-          expectCaseNoteAdded()
-          expect(res.redirect).toBeCalledWith('/prisoner/ABC123/case-notes')
         })
       })
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -27,7 +27,6 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui-dev.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-dev.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "MDI,BAI,CFI,CWI,DAI,EXI,GHI,GMI,HOI,SWI,UKI,WCI,WDI,WHI,WII,WNI"
    TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://dev.moic.service.justice.gov.uk/

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,7 +24,6 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "MDI,BAI,CFI,CWI,DAI,EXI,GHI,GMI,HOI,SWI,UKI,WCI,WDI,WHI,WII,WNI"
    TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://preprod.moic.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,6 @@ generic-service:
    INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api.hmpps.service.justice.gov.uk
    INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
-   INCENTIVES_PRIVATE_BETA_ENABLED_PRISONS: "AGI,AYI,BAI,BFI,BLI,BMI,BNI,BRI,BSI,CDI,CFI,CKI,CWI,DAI,DHI,DMI,DTI,DWI,EEI,ESI,EWI,EXI,FHI,FMI,FSI,FYI,GHI,GMI,GNI,HBI,HCI,HDI,HEI,HHI,HLI,HMI,HOI,HPI,HVI,KMI,KVI,LCI,LEI,LFI,LHI,LII,LNI,LTI,LYI,MDI,MHI,MTI,NHI,NSI,NWI,ONI,PDI,PNI,SDI,SFI,SHI,SNI,SPI,STC3,SWI,UKI,UPI,VEI,WCI,WDI,WEI,WHI,WII,WLI,WMI,WNI,WTI,WYI"
    TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://moic.service.justice.gov.uk/


### PR DESCRIPTION
Enable "record an incentive level interruption screen" regardless of the user's active case load (this is shown when a `REPORTS/REP_IEP` case note is added).

This was previously only shown in certain prison. That feature flag is now removed.

**NOTE**: This can be merged/released on Monday 3rd April.