### PR TITLE
INC-1238: Show Manage incentives tile to appropriate user groups

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -118,7 +118,6 @@ export const apis = {
   },
   incentives: {
     ui_url: process.env.INCENTIVES_URL,
-    excludedCaseloads: process.env.INCENTIVES_EXCLUDED_CASELOADS || '',
   },
   calculateReleaseDates: {
     ui_url: process.env.CALCULATE_RELEASE_DATES_URL,

--- a/backend/controllers/homepage/homepage.ts
+++ b/backend/controllers/homepage/homepage.ts
@@ -73,10 +73,7 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig, key
       description: 'See prisoner incentive information by residential location and view incentive data visualisations.',
       href: incentives.ui_url,
       roles: null,
-      enabled: () =>
-        incentives.ui_url &&
-        Boolean(locations?.length > 0) &&
-        !incentives.excludedCaseloads.split(',').includes(activeCaseLoadId),
+      enabled: () => incentives.ui_url && (userHasRoles(['MAINTAIN_INCENTIVE_LEVELS']) || locations?.length > 0),
     },
     {
       id: 'use-of-force',

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,7 +26,6 @@ generic-service:
    CHECK_MY_DIARY_URL: https://check-my-diary-dev.prison.service.justice.gov.uk?fromDPS=true
    INCENTIVES_URL: https://incentives-ui-dev.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-dev.hmpps.service.justice.gov.uk
-   INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
    TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://dev.moic.service.justice.gov.uk/
@@ -66,4 +65,3 @@ generic-service:
    KEYWORKER_MAINTENANCE_MODE: false
    GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work-dev.hmpps.service.justice.gov.uk
    WARRANT_FOLDER_URL: https://manage-a-warrant-folder-dev.hmpps.service.justice.gov.uk/
-

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,7 +23,6 @@ generic-service:
    CHECK_MY_DIARY_URL: https://check-my-diary-preprod.prison.service.justice.gov.uk?fromDPS=true
    INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-preprod.hmpps.service.justice.gov.uk
-   INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
    TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://preprod.moic.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,7 +22,6 @@ generic-service:
    CHECK_MY_DIARY_URL: https://checkmydiary.service.justice.gov.uk?fromDPS=true
    INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api.hmpps.service.justice.gov.uk
-   INCENTIVES_EXCLUDED_CASELOADS: "CADM_I"
    TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
    CASENOTES_API_URL: https://offender-case-notes.service.justice.gov.uk/
    ALLOCATION_MANAGER_ENDPOINT_URL: https://moic.service.justice.gov.uk/

--- a/integration-tests/integration/homepage/homepage.cy.js
+++ b/integration-tests/integration/homepage/homepage.cy.js
@@ -221,10 +221,7 @@ context('Homepage', () => {
       page.incentives().tile().should('exist')
       page.incentives().title().contains('Manage incentives')
       page.incentives().link().should('exist')
-      page
-        .incentives()
-        .description()
-        .contains('See prisoner incentive information by residential location and view incentive data visualisations.')
+      page.incentives().description().should('exist')
     })
 
     it('should show get someone ready to work', () => {


### PR DESCRIPTION
The tile shows for:
• regular users in a prison – would have at least one "location" _irrespective_ of their roles
• central admins – won’t have locations but will have `MAINTAIN_INCENTIVE_LEVELS` role

LSAs would need to use their normal account. An LSA’s special account would have the active case load of `CADM_I` but no locations.

NB: first commit is just to rearrange test cases; the tests themselves are unchanged