### PR TITLE
SAA-806 & SAA-825: Redirect all appointment routes to new service when rolled out

### DIFF
--- a/backend/controllers/homepage/homepage.ts
+++ b/backend/controllers/homepage/homepage.ts
@@ -307,12 +307,11 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig, key
       enabled: () => appointments.url && appointments.enabled_prisons.split(',').includes(activeCaseLoadId),
     },
     {
-      id: 'view-covid-units',
-      heading: 'View COVID units',
-      description: 'View who is in each COVID unit in your establishment.',
-      href: '/current-covid-units',
+      id: 'view-unaccounted-for',
+      heading: 'View prisoners unaccounted for',
+      description: 'View all prisoners not marked as attended or not attended.',
+      href: '/manage-prisoner-whereabouts/prisoners-unaccounted-for',
       enabled: () =>
-        userHasRoles(['PRISON']) &&
         activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
         appointments.enabled_prisons.split(',').includes(activeCaseLoadId),
     },
@@ -322,6 +321,16 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig, key
       description: 'View people due to leave this establishment for court appearances, transfers or being released.',
       href: '/manage-prisoner-whereabouts/scheduled-moves',
       enabled: () =>
+        activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
+        appointments.enabled_prisons.split(',').includes(activeCaseLoadId),
+    },
+    {
+      id: 'view-covid-units',
+      heading: 'View COVID units',
+      description: 'View who is in each COVID unit in your establishment.',
+      href: '/current-covid-units',
+      enabled: () =>
+        userHasRoles(['PRISON']) &&
         activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
         appointments.enabled_prisons.split(',').includes(activeCaseLoadId),
     },


### PR DESCRIPTION
- Redirects all appointments routes to new service if appointments is rolled out for that prison
- Redirects the add appointment route linked to from the prisoner profile to the start of the new create individual appointment journey
- Adds "View prisoners unaccounted for" tile from Whereabouts submenu
![image](https://github.com/ministryofjustice/digital-prison-services/assets/9396346/97067d86-b996-405f-bd1f-bcbe621891a5)
