### PR TITLE
MAP-36: Disable non-associations legacy mode for preprod and prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -73,7 +73,7 @@ generic-service:
    PRISONER_PROFILE_REDIRECT_URL: https://prisoner-preprod.digital.prison.service.justice.gov.uk
    PRISONER_PROFILE_REDIRECT_ENABLED_DATE: ""
    PRISONER_PROFILE_REDIRECT_ENABLED_PRISONS: LEI
-   NON_ASSOCIATIONS_LEGACY_MODE: 'true'
+   NON_ASSOCIATIONS_LEGACY_MODE: 'false'
 
   allowlist:
    office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -73,7 +73,7 @@ generic-service:
    PRISONER_PROFILE_REDIRECT_URL: https://prisoner.digital.prison.service.justice.gov.uk
    PRISONER_PROFILE_REDIRECT_ENABLED_DATE: 2023-06-12T02:00:00
    PRISONER_PROFILE_REDIRECT_ENABLED_PRISONS: LEI
-   NON_ASSOCIATIONS_LEGACY_MODE: 'true'
+   NON_ASSOCIATIONS_LEGACY_MODE: 'false'
 
   allowlist:
    office: "217.33.148.210/32"


### PR DESCRIPTION
We are ready to deploy this to production now so the feature flag can be disabled. We can completely remove the feature flag code soon, once we are sure we won't need to roll back.