### PR TITLE
SAA-967: Change add appointment redirect to appointment type agnostic link

### DIFF
--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -86,7 +86,7 @@ const isCreateIndividualAppointmentRolledOut = (req, res, next) => {
   const { activeCaseLoadId } = req.session.userDetails
   if (appointments.enabled_prisons.split(',').includes(activeCaseLoadId)) {
     const { offenderNo } = req.params
-    res.redirect(`${appointments.url}/create/start-individual?prisonNumber=${offenderNo}`)
+    res.redirect(`${appointments.url}/create/start-prisoner/${offenderNo}`)
   } else {
     next()
   }


### PR DESCRIPTION
Changes the individual appointment specific /appointments/create/start-individual?prisonNumber=A1234BC link for the prisoner profile to the more journey agnostic /appointments/create/start-prisoner/A1234BC link