### PR TITLE
MAP-158: Filter non-associations based on current location

### DIFF
--- a/backend/api/nonAssociationsApi.ts
+++ b/backend/api/nonAssociationsApi.ts
@@ -9,28 +9,26 @@ export type OffenderNonAssociation = {
   agencyDescription: string
   assignedLivingUnitDescription: string
   assignedLivingUnitId: number
-  nonAssociations: [
-    {
+  nonAssociations: {
+    reasonCode: string
+    reasonDescription: string
+    typeCode: string
+    typeDescription: string
+    effectiveDate: string
+    expiryDate: string | null
+    authorisedBy: string
+    comments: string
+    offenderNonAssociation: {
+      offenderNo: string
+      firstName: string
+      lastName: string
       reasonCode: string
       reasonDescription: string
-      typeCode: string
-      typeDescription: string
-      effectiveDate: string
-      expiryDate: string
-      authorisedBy: string
-      comments: string
-      offenderNonAssociation: {
-        offenderNo: string
-        firstName: string
-        lastName: string
-        reasonCode: string
-        reasonDescription: string
-        agencyDescription: string
-        assignedLivingUnitDescription: string
-        assignedLivingUnitId: number
-      }
+      agencyDescription: string
+      assignedLivingUnitDescription: string
+      assignedLivingUnitId: number
     }
-  ]
+  }[]
 }
 
 export const nonAssociationsApiFactory = (client: OauthApiClient) => {

--- a/backend/controllers/cellMove/searchForCell.ts
+++ b/backend/controllers/cellMove/searchForCell.ts
@@ -34,7 +34,8 @@ export default ({ oauthApi, prisonApi, whereaboutsApi, nonAssociationsApi }) =>
           (alert) => prisonersActiveAlertCodes.includes(alert) && cellMoveAlertCodes.includes(alert)
         )
       )
-      const numberOfNonAssociations = getNonAssociationsInEstablishment(nonAssociations).length
+      const numberOfNonAssociations = (await getNonAssociationsInEstablishment(nonAssociations, res.locals, prisonApi))
+        .length
 
       const prisonerDetailsWithFormattedLocation = {
         ...prisonerDetails,

--- a/backend/controllers/cellMove/selectCell.ts
+++ b/backend/controllers/cellMove/selectCell.ts
@@ -192,7 +192,8 @@ export default ({ oauthApi, prisonApi, whereaboutsApi, nonAssociationsApi }) =>
         nonAssociations,
       })
 
-      const numberOfNonAssociations = getNonAssociationsInEstablishment(nonAssociations).length
+      const numberOfNonAssociations = (await getNonAssociationsInEstablishment(nonAssociations, res.locals, prisonApi))
+        .length
 
       const prisonerDetailsWithFormattedLocation = {
         ...prisonerDetails,

--- a/backend/controllers/cellMove/viewNonAssociations.ts
+++ b/backend/controllers/cellMove/viewNonAssociations.ts
@@ -12,15 +12,15 @@ export default ({ prisonApi, nonAssociationsApi }) =>
 
       // Only show active non-associations in the same establishment
       // Active means the effective date is not in the future and the expiry date is not in the past
-      const sortedNonAssociationsInEstablishment = getNonAssociationsInEstablishment(nonAssociations).sort(
-        (left, right) => {
-          if (left.effectiveDate < right.effectiveDate) return 1
-          if (right.effectiveDate < left.effectiveDate) return -1
-          if (left.offenderNonAssociation.lastName > right.offenderNonAssociation.lastName) return 1
-          if (right.offenderNonAssociation.lastName > left.offenderNonAssociation.lastName) return -1
-          return 0
-        }
-      )
+      const sortedNonAssociationsInEstablishment = (
+        await getNonAssociationsInEstablishment(nonAssociations, res.locals, prisonApi)
+      ).sort((left, right) => {
+        if (left.effectiveDate < right.effectiveDate) return 1
+        if (right.effectiveDate < left.effectiveDate) return -1
+        if (left.offenderNonAssociation.lastName > right.offenderNonAssociation.lastName) return 1
+        if (right.offenderNonAssociation.lastName > left.offenderNonAssociation.lastName) return -1
+        return 0
+      })
 
       const nonAssociationsRows = sortedNonAssociationsInEstablishment?.map((nonAssociation) => ({
         name: putLastNameFirst(

--- a/backend/tests/cellMove/cellMoveUtils.test.ts
+++ b/backend/tests/cellMove/cellMoveUtils.test.ts
@@ -1,0 +1,215 @@
+import moment from 'moment'
+import { getNonAssociationsInEstablishment } from '../../controllers/cellMove/cellMoveUtils'
+
+describe('Cell move utils', () => {
+  const nonAssociations = {
+    offenderNo: 'ABC123',
+    firstName: 'Fred',
+    lastName: 'Bloggs',
+    agencyDescription: 'Moorland (HMP & YOI)',
+    assignedLivingUnitDescription: 'MDI-1-1-3',
+    assignedLivingUnitId: 180353,
+    nonAssociations: [
+      {
+        reasonCode: 'VIC',
+        reasonDescription: 'Victim',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: moment().add(7, 'days').format('YYYY-MM-DDTHH:mm:ss'),
+        expiryDate: null,
+        authorisedBy: 'string',
+        comments: 'Not effective yet',
+        offenderNonAssociation: {
+          offenderNo: 'ABC124',
+          firstName: 'Andy',
+          lastName: 'Adams',
+          reasonCode: 'PER',
+          reasonDescription: 'Perpetrator',
+          agencyDescription: 'Moorland (HMP & YOI)',
+          assignedLivingUnitDescription: 'MDI-2-1-3',
+          assignedLivingUnitId: 123,
+        },
+      },
+      {
+        reasonCode: 'VIC',
+        reasonDescription: 'Victim',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: moment().format('YYYY-MM-DDTHH:mm:ss'),
+        expiryDate: null,
+        authorisedBy: 'string',
+        comments: 'Effective from today',
+        offenderNonAssociation: {
+          offenderNo: 'ABC125',
+          firstName: 'Brian',
+          lastName: 'Blessed',
+          reasonCode: 'PER',
+          reasonDescription: 'Perpetrator',
+          agencyDescription: 'Moorland (HMP & YOI)',
+          assignedLivingUnitDescription: 'MDI-2-1-3',
+          assignedLivingUnitId: 123,
+        },
+      },
+      {
+        reasonCode: 'RIV',
+        reasonDescription: 'Rival gang',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: moment().subtract(1, 'years').format('YYYY-MM-DDTHH:mm:ss'),
+        expiryDate: moment().add(1, 'days').format('YYYY-MM-DDTHH:mm:ss'),
+        authorisedBy: 'string',
+        comments: 'Effective until tomorrow',
+        offenderNonAssociation: {
+          offenderNo: 'ABC126',
+          firstName: 'Clarence',
+          lastName: 'Cook',
+          reasonCode: 'RIV',
+          reasonDescription: 'Rival gang',
+          agencyDescription: 'Moorland (HMP & YOI)',
+          assignedLivingUnitDescription: 'MDI-2-1-3',
+          assignedLivingUnitId: 123,
+        },
+      },
+      {
+        reasonCode: 'VIC',
+        reasonDescription: 'Victim',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: '2018-12-01T13:34:00',
+        expiryDate: '2019-12-01T13:34:00',
+        authorisedBy: 'string',
+        comments: 'This one has expired',
+        offenderNonAssociation: {
+          offenderNo: 'ABC127',
+          firstName: 'Dave',
+          lastName: 'Digby',
+          reasonCode: 'PER',
+          reasonDescription: 'Perpetrator',
+          agencyDescription: 'Moorland (HMP & YOI)',
+          assignedLivingUnitDescription: 'MDI-2-1-3',
+          assignedLivingUnitId: 123,
+        },
+      },
+      {
+        reasonCode: 'VIC',
+        reasonDescription: 'Victim',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: '2018-12-01T13:34:00',
+        expiryDate: null,
+        authorisedBy: 'string',
+        comments: 'From an old booking',
+        offenderNonAssociation: {
+          offenderNo: 'ABC128',
+          firstName: 'Emily',
+          lastName: 'Egerton',
+          reasonCode: 'PER',
+          reasonDescription: 'Perpetrator',
+          agencyDescription: 'OUTSIDE',
+          assignedLivingUnitDescription: 'MDI-2-1-3',
+          assignedLivingUnitId: 123,
+        },
+      },
+      {
+        reasonCode: 'VIC',
+        reasonDescription: 'Victim',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: '2018-12-01T13:34:00',
+        expiryDate: null,
+        authorisedBy: 'string',
+        comments: 'From an old booking',
+        offenderNonAssociation: {
+          offenderNo: 'ABC129',
+          firstName: 'Frank',
+          lastName: 'Fibonacci',
+          reasonCode: 'PER',
+          reasonDescription: 'Perpetrator',
+          agencyDescription: 'Moorland (HMP & YOI)',
+          assignedLivingUnitDescription: 'MDI-2-1-3',
+          assignedLivingUnitId: 123,
+        },
+      },
+    ],
+  }
+
+  const prisonApi = {
+    getDetails: jest.fn((_, offenderNo) => {
+      return {
+        agencyId: offenderNo === 'ABC129' ? 'BXI' : 'MDI',
+        offenderNo,
+      }
+    }),
+  }
+
+  describe('getNonAssociationsInEstablishment', () => {
+    let result
+
+    beforeAll(async () => {
+      result = await getNonAssociationsInEstablishment(nonAssociations, {}, prisonApi)
+    })
+
+    it('returns valid non-associations', async () => {
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          offenderNonAssociation: expect.objectContaining({
+            firstName: 'Brian',
+            lastName: 'Blessed',
+          }),
+        })
+      )
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          offenderNonAssociation: expect.objectContaining({
+            firstName: 'Clarence',
+            lastName: 'Cook',
+          }),
+        })
+      )
+    })
+
+    it('filters out expired non-associations', async () => {
+      expect(result).not.toContainEqual(
+        expect.objectContaining({
+          offenderNonAssociation: expect.objectContaining({
+            firstName: 'Dave',
+            lastName: 'Digby',
+          }),
+        })
+      )
+    })
+
+    it('filters out not yet effective non-associations', async () => {
+      expect(result).not.toContainEqual(
+        expect.objectContaining({
+          offenderNonAssociation: expect.objectContaining({
+            firstName: 'Andy',
+            lastName: 'Adams',
+          }),
+        })
+      )
+    })
+
+    it('includes non-associations from old bookings', async () => {
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          offenderNonAssociation: expect.objectContaining({
+            firstName: 'Emily',
+            lastName: 'Egerton',
+          }),
+        })
+      )
+    })
+
+    it('filters out non-associations with a different current location', async () => {
+      expect(result).not.toContainEqual(
+        expect.objectContaining({
+          offenderNonAssociation: expect.objectContaining({
+            firstName: 'Frank',
+            lastName: 'Fibonacci',
+          }),
+        })
+      )
+    })
+  })
+})

--- a/integration-tests/integration/cellMove/searchForCell.cy.js
+++ b/integration-tests/integration/cellMove/searchForCell.cy.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const SearchForCellPage = require('../../pages/cellMove/searchForCellPage')
 const OffenderDetailsPage = require('../../pages/cellMove/offenderDetailsPage')
@@ -14,6 +15,7 @@ context('A user can search for a cell', () => {
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
+    cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubOffenderNonAssociations', {})
     cy.task('stubGroups', { id: 'MDI' })

--- a/integration-tests/integration/cellMove/selectCell.cy.js
+++ b/integration-tests/integration/cellMove/selectCell.cy.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const SelectCellPage = require('../../pages/cellMove/selectCellPage')
 
@@ -29,6 +30,7 @@ context('A user can select a cell', () => {
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
+    cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubGroups', { id: 'MDI' })
     cy.task('stubCellAttributes')


### PR DESCRIPTION
Previously we were filtering non-associations based on the location from the non-association record. This creates problems if the non-association was created against a previous booking, as the last location will be `OUTSIDE`. Now we check the current location of each prisoner and compare them instead.