### PR TITLE
MAP-158: Display correct cell location when displaying non-associations

### DIFF
--- a/backend/controllers/cellMove/cellMoveUtils.ts
+++ b/backend/controllers/cellMove/cellMoveUtils.ts
@@ -21,18 +21,24 @@ export const getNonAssociationsInEstablishment = async (
   offenderNos.push(nonAssociations.offenderNo)
 
   const offenders = await Promise.all(
-    offenderNos.map(async (offenderNo) => prisonApi.getDetails(context, offenderNo, false))
+    offenderNos.map(async (offenderNo) => prisonApi.getDetails(context, offenderNo, true))
   )
 
-  const offenderLocations = offenders.reduce(
-    (memo, offender) => ({ ...memo, [offender.offenderNo]: offender.agencyId }),
-    {}
-  )
+  const offenderMap = offenders.reduce((memo, offender) => ({ ...memo, [offender.offenderNo]: offender }), {})
+
+  validNonAssociations.forEach((nonAssociation) => {
+    const livingUnit = offenderMap[nonAssociation.offenderNonAssociation.offenderNo]?.assignedLivingUnit
+
+    /* eslint-disable no-param-reassign */
+    nonAssociation.offenderNonAssociation.agencyDescription = livingUnit?.agencyName
+    nonAssociation.offenderNonAssociation.assignedLivingUnitDescription = livingUnit?.description
+    /* eslint-enable no-param-reassign */
+  })
 
   return validNonAssociations.filter(
     (nonAssociation) =>
-      offenderLocations[nonAssociations.offenderNo] ===
-      offenderLocations[nonAssociation.offenderNonAssociation.offenderNo]
+      offenderMap[nonAssociations.offenderNo].agencyId ===
+      offenderMap[nonAssociation.offenderNonAssociation.offenderNo].agencyId
   )
 }
 

--- a/backend/tests/cellMove/cellMoveUtils.test.ts
+++ b/backend/tests/cellMove/cellMoveUtils.test.ts
@@ -135,9 +135,17 @@ describe('Cell move utils', () => {
 
   const prisonApi = {
     getDetails: jest.fn((_, offenderNo) => {
+      const agencyId = offenderNo === 'ABC129' ? 'BXI' : 'MDI'
+
       return {
-        agencyId: offenderNo === 'ABC129' ? 'BXI' : 'MDI',
+        agencyId,
         offenderNo,
+        assignedLivingUnit: {
+          agencyId,
+          locationId: 12345,
+          description: '1-2-012',
+          agencyName: 'Ye olde prisone',
+        },
       }
     }),
   }

--- a/backend/tests/cellMove/searchForCell.test.ts
+++ b/backend/tests/cellMove/searchForCell.test.ts
@@ -125,7 +125,11 @@ describe('select location', () => {
     }
     res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
-    prisonApi.getDetails = jest.fn().mockResolvedValue(getDetailsResponse)
+    prisonApi.getDetails = jest.fn().mockImplementation((_, requestedOffenderNo) => ({
+      ...getDetailsResponse,
+      offenderNo: requestedOffenderNo,
+    }))
+
     nonAssociationsApi.getNonAssociations = jest.fn().mockResolvedValue({ nonAssociations: [] })
 
     whereaboutsApi.searchGroups = jest.fn().mockResolvedValue([

--- a/backend/tests/cellMove/selectCell.test.ts
+++ b/backend/tests/cellMove/selectCell.test.ts
@@ -55,10 +55,10 @@ describe('Select a cell', () => {
   beforeEach(() => {
     oauthApi.userRoles = jest.fn().mockReturnValue([{ roleCode: 'CELL_MOVE' }])
     prisonApi.userCaseLoads = jest.fn().mockResolvedValue([{ caseLoadId: 'LEI' }])
-    prisonApi.getDetails = jest.fn().mockResolvedValue({
+    prisonApi.getDetails = jest.fn().mockImplementation((_, offenderNo) => ({
       firstName: 'John',
       lastName: 'Doe',
-      offenderNo: someOffenderNumber,
+      offenderNo,
       bookingId: someBookingId,
       agencyId: someAgency,
       alerts: [
@@ -67,7 +67,13 @@ describe('Select a cell', () => {
         { expired: false, alertCode: 'HA' },
         { expired: false, alertCode: 'HA1' },
       ],
-    })
+      assignedLivingUnit: {
+        agencyId: someAgency,
+        locationId: 12345,
+        description: '1-2-012',
+        agencyName: 'ye olde prisone',
+      },
+    }))
 
     prisonApi.getCsraAssessments = jest.fn()
     prisonApi.getAlerts = jest.fn()
@@ -211,7 +217,12 @@ describe('Select a cell', () => {
             firstName: 'John',
             lastName: 'Doe',
             offenderNo: 'A12345',
-            assignedLivingUnit: {},
+            assignedLivingUnit: {
+              agencyId: someAgency,
+              locationId: 12345,
+              description: '1-2-012',
+              agencyName: 'ye olde prisone',
+            },
           },
         })
       )
@@ -813,14 +824,6 @@ describe('Select a cell', () => {
     })
 
     it('should set show non association value to true when there are res unit level non-associations', async () => {
-      prisonApi.getDetails = jest.fn().mockResolvedValue({
-        firstName: 'John',
-        lastName: 'Doe',
-        offenderNo: someOffenderNumber,
-        bookingId: someBookingId,
-        agencyId: someAgency,
-        alerts: [],
-      })
       prisonApi.getLocation
         .mockResolvedValueOnce(cellLocationData)
         .mockResolvedValueOnce(parentLocationData)
@@ -851,14 +854,25 @@ describe('Select a cell', () => {
 
     it('should set show non association value to true when there are non-associations within the establishment', async () => {
       prisonApi.userCaseLoads = jest.fn().mockResolvedValue([{ caseLoadId: 'MDI' }])
-      prisonApi.getDetails = jest.fn().mockResolvedValue({
+      prisonApi.getDetails = jest.fn().mockImplementation((_, offenderNo) => ({
         firstName: 'John',
         lastName: 'Doe',
-        offenderNo: someOffenderNumber,
+        offenderNo,
         bookingId: someBookingId,
         agencyId: 'MDI',
-        alerts: [],
-      })
+        alerts: [
+          { expired: false, alertCode: 'PEEP' },
+          { expired: true, alertCode: 'DCC' },
+          { expired: false, alertCode: 'HA' },
+          { expired: false, alertCode: 'HA1' },
+        ],
+        assignedLivingUnit: {
+          agencyId: 'MDI',
+          locationId: 12345,
+          description: '1-2-012',
+          agencyName: 'ye olde prisone',
+        },
+      }))
 
       req.query = {}
 

--- a/backend/tests/cellMove/viewNonAssociations.test.ts
+++ b/backend/tests/cellMove/viewNonAssociations.test.ts
@@ -25,6 +25,12 @@ describe('view non associations', () => {
     offenderNo,
     firstName: 'Test',
     lastName: 'User',
+    assignedLivingUnit: {
+      agencyId: 'MDI',
+      locationId: 12345,
+      description: '1-2-012',
+      agencyName: 'Moorland (HMP & YOI)',
+    },
   }
 
   beforeEach(() => {
@@ -38,7 +44,11 @@ describe('view non associations', () => {
     }
     res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
-    prisonApi.getDetails = jest.fn().mockResolvedValue(getDetailsResponse)
+    prisonApi.getDetails = jest.fn().mockImplementation((_, requestedOffenderNo) => ({
+      ...getDetailsResponse,
+      offenderNo: requestedOffenderNo,
+    }))
+
     nonAssociationsApi.getNonAssociations = jest.fn().mockResolvedValue({
       offenderNo: 'ABC123',
       firstName: 'Fred',
@@ -152,7 +162,7 @@ describe('view non associations', () => {
           {
             comment: 'Test comment 1',
             effectiveDate: moment().format('D MMMM YYYY'),
-            location: 'MDI-2-1-3',
+            location: '1-2-012',
             name: 'Bloggs, Joseph',
             otherOffenderKey: 'Joseph Bloggs is',
             otherOffenderRole: 'Perpetrator',
@@ -164,7 +174,7 @@ describe('view non associations', () => {
           {
             comment: 'Test comment 2',
             effectiveDate: moment().subtract(1, 'years').format('D MMMM YYYY'),
-            location: 'MDI-2-1-3',
+            location: '1-2-012',
             name: 'Bloggs, Jim',
             otherOffenderKey: 'Jim Bloggs is',
             otherOffenderRole: 'Rival gang',

--- a/integration-tests/integration/cellMove/searchForCell.cy.js
+++ b/integration-tests/integration/cellMove/searchForCell.cy.js
@@ -1,5 +1,4 @@
 const moment = require('moment')
-const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const SearchForCellPage = require('../../pages/cellMove/searchForCellPage')
 const OffenderDetailsPage = require('../../pages/cellMove/offenderDetailsPage')
@@ -15,7 +14,6 @@ context('A user can search for a cell', () => {
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubOffenderNonAssociations', {})
     cy.task('stubGroups', { id: 'MDI' })
@@ -80,15 +78,24 @@ context('A user can search for a cell', () => {
             assessmentDescription: 'CSR',
           },
         ],
+        assignedLivingUnit: {
+          agencyId: 'MDI',
+          locationId: 12345,
+          description: 'HMP Moorland',
+          agencyName: 'Moorland (HMP & YOI)',
+        },
       })
       cy.task('stubOffenderNonAssociations', {
         agencyDescription: 'HMP Moorland',
+        offenderNo: 'G3878UK',
         nonAssociations: [
           {
             effectiveDate: moment(),
             expiryDate: moment().add(2, 'days'),
             offenderNonAssociation: {
               agencyDescription: 'HMP Moorland',
+              assignedLivingUnitDescription: 'HMP Moorland',
+              offenderNo: 'G3878UK',
             },
           },
         ],

--- a/integration-tests/integration/cellMove/selectCell.cy.js
+++ b/integration-tests/integration/cellMove/selectCell.cy.js
@@ -1,5 +1,4 @@
 const moment = require('moment')
-const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const SelectCellPage = require('../../pages/cellMove/selectCellPage')
 
@@ -30,8 +29,12 @@ context('A user can select a cell', () => {
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('stubOffenderBasicDetails', offenderBasicDetails)
-    cy.task('stubOffenderFullDetails', offenderFullDetails)
+    ;['A12345', 'G6123VU'].forEach((anotherOffenderNo) => {
+      cy.task('stubSpecificOffenderFullDetails', {
+        ...offenderFullDetails,
+        offenderNo: anotherOffenderNo,
+      })
+    })
     cy.task('stubGroups', { id: 'MDI' })
     cy.task('stubCellAttributes')
     cy.task('stubInmatesAtLocation', {

--- a/integration-tests/integration/cellMove/viewNonAssociations.cy.js
+++ b/integration-tests/integration/cellMove/viewNonAssociations.cy.js
@@ -1,6 +1,7 @@
 const moment = require('moment')
 
 const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
+const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const NonAssociationsPage = require('../../pages/cellMove/nonAssociationsPage')
 
 const offenderNo = 'A12345'
@@ -16,6 +17,36 @@ context('A user can view non associations', () => {
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
     cy.task('stubOffenderBasicDetails', offenderBasicDetails)
+    cy.task('stubSpecificOffenderFullDetails', {
+      ...offenderFullDetails,
+      offenderNo,
+      assignedLivingUnit: {
+        agencyId: 'MDI',
+        locationId: 12345,
+        description: 'MDI-1-1-3',
+        agencyName: 'Moorland (HMP & YOI)',
+      },
+    })
+    cy.task('stubSpecificOffenderFullDetails', {
+      ...offenderFullDetails,
+      offenderNo: 'ABC124',
+      assignedLivingUnit: {
+        agencyId: 'MDI',
+        locationId: 12345,
+        description: 'MDI-2-1-2',
+        agencyName: 'Moorland (HMP & YOI)',
+      },
+    })
+    cy.task('stubSpecificOffenderFullDetails', {
+      ...offenderFullDetails,
+      offenderNo: 'ABC125',
+      assignedLivingUnit: {
+        agencyId: 'MDI',
+        locationId: 12345,
+        description: 'MDI-2-1-3',
+        agencyName: 'Moorland (HMP & YOI)',
+      },
+    })
     cy.task('stubOffenderNonAssociations', {
       offenderNo: 'A12345',
       firstName: 'John',

--- a/integration-tests/mockApis/prisonApi.js
+++ b/integration-tests/mockApis/prisonApi.js
@@ -278,6 +278,20 @@ module.exports = {
         jsonBody: details || {},
       },
     }),
+  stubSpecificOffenderFullDetails: (details) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/api/bookings/offenderNo/${details.offenderNo}\\?fullInfo=true&csraSummary=true`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: details || {},
+      },
+    }),
   stubOffenderBasicDetails: (offender) =>
     stubFor({
       request: {


### PR DESCRIPTION
Non-associations from past bookings were not displaying the living unit description when the summary was viewed