### PR TITLE
SAA-1018: Remove unused activities tile. Redirect when activities rolled out

### DIFF
--- a/backend/controllers/getConfig.ts
+++ b/backend/controllers/getConfig.ts
@@ -10,6 +10,8 @@ export const getConfiguration = asyncMiddleware(async (req, res) =>
     flags: (config.app as any).featureFlags,
     supportUrl: config.app.supportUrl,
     authUrl: config.apis.oauth2.url,
+    activities: config.apis.activities,
+    appointments: config.apis.appointments,
   })
 )
 

--- a/backend/controllers/homepage/homepage.ts
+++ b/backend/controllers/homepage/homepage.ts
@@ -308,15 +308,6 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig, key
       enabled: () => appointments.url && appointments.enabled_prisons.split(',').includes(activeCaseLoadId),
     },
     {
-      id: 'view-unaccounted-for',
-      heading: 'View prisoners unaccounted for',
-      description: 'View all prisoners not marked as attended or not attended.',
-      href: '/manage-prisoner-whereabouts/prisoners-unaccounted-for',
-      enabled: () =>
-        activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
-        appointments.enabled_prisons.split(',').includes(activeCaseLoadId),
-    },
-    {
       id: 'view-people-due-to-leave',
       heading: 'People due to leave',
       description: 'View people due to leave this establishment for court appearances, transfers or being released.',

--- a/src/App.js
+++ b/src/App.js
@@ -221,7 +221,9 @@ class App extends React.Component {
       config.activities.enabled_prisons.split(',').includes(user.activeCaseLoadId)
     ) {
       window.location = '/'
+      return true
     }
+    return false
   }
 
   render() {
@@ -283,24 +285,24 @@ class App extends React.Component {
           <Route
             exact
             path={routePaths.prisonersUnaccountedFor}
-            location={() => {
-              this.redirectIfActivitiesRolledOut()
+            render={({ history }) => {
+              if (this.redirectIfActivitiesRolledOut()) return null
+              return (
+                <PrisonersUnaccountedForContainer
+                  handleDateChange={(event) => this.handleDateChange(event)}
+                  handlePeriodChange={(event) => this.handlePeriodChange(event)}
+                  handleError={this.handleError}
+                  setLoadedDispatch={setLoadedDispatch}
+                  setErrorDispatch={setErrorDispatch}
+                  resetErrorDispatch={resetErrorDispatch}
+                  raiseAnalyticsEvent={this.raiseAnalyticsEvent}
+                  showModal={setShowModalDispatch}
+                  setOffenderPaymentDataDispatch={setOffenderPaymentDataDispatch}
+                  getAbsentReasonsDispatch={getAbsentReasonsDispatch}
+                  history={history}
+                />
+              )
             }}
-            render={({ history }) => (
-              <PrisonersUnaccountedForContainer
-                handleDateChange={(event) => this.handleDateChange(event)}
-                handlePeriodChange={(event) => this.handlePeriodChange(event)}
-                handleError={this.handleError}
-                setLoadedDispatch={setLoadedDispatch}
-                setErrorDispatch={setErrorDispatch}
-                resetErrorDispatch={resetErrorDispatch}
-                raiseAnalyticsEvent={this.raiseAnalyticsEvent}
-                showModal={setShowModalDispatch}
-                setOffenderPaymentDataDispatch={setOffenderPaymentDataDispatch}
-                getAbsentReasonsDispatch={getAbsentReasonsDispatch}
-                history={history}
-              />
-            )}
           />
         </div>
       </div>
@@ -376,14 +378,14 @@ App.propTypes = {
     flags: PropTypes.objectOf(PropTypes.string),
     supportUrl: PropTypes.string,
     authUrl: PropTypes.string,
-    activities: {
+    activities: PropTypes.shape({
       url: PropTypes.string,
       enabled_prisons: PropTypes.string,
-    },
-    appointments: {
+    }),
+    appointments: PropTypes.shape({
       url: PropTypes.string,
       enabled_prisons: PropTypes.string,
-    },
+    }),
   }).isRequired,
   date: PropTypes.string.isRequired,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({ message: PropTypes.string })]),

--- a/src/App.js
+++ b/src/App.js
@@ -211,6 +211,19 @@ class App extends React.Component {
     userDetailsDispatch({ ...user.data, activeCaseLoadId, caseLoadOptions: caseloads.data, roles: roles.data })
   }
 
+  redirectIfActivitiesRolledOut = () => {
+    const { config, user } = this.props
+
+    if (
+      config &&
+      config.activities &&
+      config.activities.enabled_prisons &&
+      config.activities.enabled_prisons.split(',').includes(user.activeCaseLoadId)
+    ) {
+      window.location = '/'
+    }
+  }
+
   render() {
     const {
       config,
@@ -271,14 +284,7 @@ class App extends React.Component {
             exact
             path={routePaths.prisonersUnaccountedFor}
             location={() => {
-              if (
-                config &&
-                config.activities &&
-                config.activities.enabled_prisons &&
-                config.activities.enabled_prisons.split(',').includes(user.activeCaseLoadId)
-              ) {
-                window.location = '/'
-              }
+              this.redirectIfActivitiesRolledOut()
             }}
             render={({ history }) => (
               <PrisonersUnaccountedForContainer

--- a/src/App.js
+++ b/src/App.js
@@ -270,6 +270,16 @@ class App extends React.Component {
           <Route
             exact
             path={routePaths.prisonersUnaccountedFor}
+            location={() => {
+              if (
+                config &&
+                config.activities &&
+                config.activities.enabled_prisons &&
+                config.activities.enabled_prisons.split(',').includes(user.activeCaseLoadId)
+              ) {
+                window.location = '/'
+              }
+            }}
             render={({ history }) => (
               <PrisonersUnaccountedForContainer
                 handleDateChange={(event) => this.handleDateChange(event)}
@@ -360,6 +370,14 @@ App.propTypes = {
     flags: PropTypes.objectOf(PropTypes.string),
     supportUrl: PropTypes.string,
     authUrl: PropTypes.string,
+    activities: {
+      url: PropTypes.string,
+      enabled_prisons: PropTypes.string,
+    },
+    appointments: {
+      url: PropTypes.string,
+      enabled_prisons: PropTypes.string,
+    },
   }).isRequired,
   date: PropTypes.string.isRequired,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({ message: PropTypes.string })]),


### PR DESCRIPTION
When activities is rolled out for a prison:

- The "View prisoners unaccounted for" tile will no longer be shown on the DPS homepage or Whereabouts sub menu
- The /manage-prisoner-whereabouts/prisoners-unaccounted-for route for the "View prisoners unaccounted for" will redirect to the DPS homepage in line with the other replaced Whereabouts routes

![image](https://github.com/ministryofjustice/digital-prison-services/assets/9396346/dc94b5fd-71b9-4b0c-8583-69e643576a3d)
