### PR TITLE
MAP-202: Fix cell moves bug with non-associations in other establishments

### DIFF
--- a/backend/tests/cellMove/cellMoveUtils.test.ts
+++ b/backend/tests/cellMove/cellMoveUtils.test.ts
@@ -130,11 +130,35 @@ describe('Cell move utils', () => {
           assignedLivingUnitId: 123,
         },
       },
+      {
+        reasonCode: 'VIC',
+        reasonDescription: 'Victim',
+        typeCode: 'WING',
+        typeDescription: 'Do Not Locate on Same Wing',
+        effectiveDate: '2018-12-01T13:34:00',
+        expiryDate: null,
+        authorisedBy: 'string',
+        comments: 'Is in an establisment which the user does not have as a caseload',
+        offenderNonAssociation: {
+          offenderNo: 'ABC130',
+          firstName: 'George',
+          lastName: 'Gauss',
+          reasonCode: 'PER',
+          reasonDescription: 'Perpetrator',
+          agencyDescription: 'Brixton (HMP)',
+          assignedLivingUnitDescription: 'BXI-1-1-1',
+          assignedLivingUnitId: 123,
+        },
+      },
     ],
   }
 
   const prisonApi = {
     getDetails: jest.fn((_, offenderNo) => {
+      if (offenderNo === 'ABC130') {
+        throw new Error('Not found')
+      }
+
       const agencyId = offenderNo === 'ABC129' ? 'BXI' : 'MDI'
 
       return {


### PR DESCRIPTION
We recently updated the cell moves code to pull the details of each non-association via the prison API. This uses the currently logged-in user's creds, and they may not have permissions to view users in other establishments. This was causing errors when requesting cell moves for some prisoners. The fix is to ignore the failed lookups as we only care about prisoners in the same establishment anyway.