### PR TITLE
MAP-246: Change cell moves breadcrumbs to back buttons

### DIFF
--- a/backend/controllers/cellMove/considerRisks.ts
+++ b/backend/controllers/cellMove/considerRisks.ts
@@ -183,6 +183,7 @@ export default ({ prisonApi, raiseAnalyticsEvent, nonAssociationsApi }) => {
           currentOccupantsWithFormattedActiveAlerts.length > 0 ||
           categoryWarning,
         errors,
+        backUrl: `${profileUrl}/cell-move/select-cell`,
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-history`

--- a/backend/controllers/cellMove/searchForCell.ts
+++ b/backend/controllers/cellMove/searchForCell.ts
@@ -45,6 +45,13 @@ export default ({ oauthApi, prisonApi, whereaboutsApi, nonAssociationsApi }) =>
         },
       }
 
+      let backUrl = req.headers.referer
+      // If the referrer is a later page in the journey (i.e. the user already clicked back to get here), make the back
+      // link point to the prisoner search page instead
+      if (!backUrl || backUrl.endsWith('/cell-move/select-cell') || backUrl.endsWith('/cell-move/confirm-cell-move')) {
+        backUrl = '/change-someones-cell/prisoner-search'
+      }
+
       return res.render('cellMove/searchForCell.njk', {
         breadcrumbPrisonerName: putLastNameFirst(prisonerDetails.firstName, prisonerDetails.lastName),
         prisonerName: formatName(prisonerDetails.firstName, prisonerDetails.lastName),
@@ -62,6 +69,7 @@ export default ({ oauthApi, prisonApi, whereaboutsApi, nonAssociationsApi }) =>
         formAction: `/prisoner/${offenderNo}/cell-move/select-cell`,
         profileUrl: `/prisoner/${offenderNo}`,
         convertedCsra: translateCsra(prisonerDetails.csraClassificationCode),
+        backUrl,
       })
     } catch (error) {
       res.locals.homeUrl = `/prisoner/${offenderNo}`

--- a/backend/controllers/cellMove/selectCell.ts
+++ b/backend/controllers/cellMove/selectCell.ts
@@ -235,6 +235,7 @@ export default ({ oauthApi, prisonApi, whereaboutsApi, nonAssociationsApi }) =>
         selectCellRootUrl: `/prisoner/${offenderNo}/cell-move/select-cell`,
         formAction: `/prisoner/${offenderNo}/cell-move/select-cell`,
         convertedCsra: translateCsra(prisonerDetails.csraClassificationCode),
+        backUrl: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`

--- a/backend/tests/cellMove/considerRisks.test.ts
+++ b/backend/tests/cellMove/considerRisks.test.ts
@@ -521,6 +521,7 @@ describe('move validation', () => {
       selectCellUrl: '/prisoner/ABC123/cell-move/select-cell',
       showOffendersNamesWithCsra: true,
       showRisks: true,
+      backUrl: '/prisoner/ABC123/cell-move/select-cell',
     })
   })
 

--- a/backend/tests/cellMove/searchForCell.test.ts
+++ b/backend/tests/cellMove/searchForCell.test.ts
@@ -122,6 +122,7 @@ describe('select location', () => {
       query: {},
       protocol: 'http',
       get: jest.fn().mockReturnValue('localhost'),
+      headers: {},
     }
     res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
@@ -354,6 +355,76 @@ describe('select location', () => {
           ],
         })
       )
+    })
+
+    describe('back link', () => {
+      it('links back to the prisoner search page when there is no referrer', async () => {
+        await controller(req, res)
+
+        expect(res.render).toHaveBeenCalledWith(
+          'cellMove/searchForCell.njk',
+          expect.objectContaining({
+            backUrl: '/change-someones-cell/prisoner-search',
+          })
+        )
+      })
+
+      it('links back to the prisoner search page when referred back from select-cell', async () => {
+        await controller(
+          {
+            ...req,
+            headers: {
+              referer: 'http://dps/prisoner/G0637UO/cell-move/select-cell',
+            },
+          },
+          res
+        )
+
+        expect(res.render).toHaveBeenCalledWith(
+          'cellMove/searchForCell.njk',
+          expect.objectContaining({
+            backUrl: '/change-someones-cell/prisoner-search',
+          })
+        )
+      })
+
+      it('links back to the prisoner search page when referred back from confirm-cell-move', async () => {
+        await controller(
+          {
+            ...req,
+            headers: {
+              referer: 'http://dps/prisoner/G0637UO/cell-move/confirm-cell-move',
+            },
+          },
+          res
+        )
+
+        expect(res.render).toHaveBeenCalledWith(
+          'cellMove/searchForCell.njk',
+          expect.objectContaining({
+            backUrl: '/change-someones-cell/prisoner-search',
+          })
+        )
+      })
+
+      it('links back to the page the user came from in any other case', async () => {
+        await controller(
+          {
+            ...req,
+            headers: {
+              referer: '/dps/some/other/page',
+            },
+          },
+          res
+        )
+
+        expect(res.render).toHaveBeenCalledWith(
+          'cellMove/searchForCell.njk',
+          expect.objectContaining({
+            backUrl: '/dps/some/other/page',
+          })
+        )
+      })
     })
   })
 })

--- a/backend/tests/cellMove/selectCell.test.ts
+++ b/backend/tests/cellMove/selectCell.test.ts
@@ -185,12 +185,13 @@ describe('Select a cell', () => {
       expect(res.render).toHaveBeenCalledWith(
         'cellMove/selectCell.njk',
         expect.objectContaining({
+          backUrl: '/prisoner/A12345/cell-move/search-for-cell',
           csraDetailsUrl: '/prisoner/A12345/cell-move/cell-sharing-risk-assessment-details',
           formAction: '/prisoner/A12345/cell-move/select-cell',
           nonAssociationLink: '/prisoner/A12345/cell-move/non-associations',
           offenderDetailsUrl: '/prisoner/A12345/cell-move/prisoner-details',
-          selectCellRootUrl: '/prisoner/A12345/cell-move/select-cell',
           searchForCellRootUrl: '/prisoner/A12345/cell-move/search-for-cell',
+          selectCellRootUrl: '/prisoner/A12345/cell-move/select-cell',
           showNonAssociationsLink: false,
         })
       )

--- a/integration-tests/integration/cellMove/confirmCellMove.cy.js
+++ b/integration-tests/integration/cellMove/confirmCellMove.cy.js
@@ -76,6 +76,14 @@ context('A user can confirm the cell move', () => {
     cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/search-for-cell')
   })
 
+  it('should have a back button leading to search for cell', () => {
+    ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
+
+    cy.contains('Back').click()
+
+    cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/search-for-cell')
+  })
+
   it('should not mention c-swap or show form inputs', () => {
     const page = ConfirmCellMovePage.goTo('A12345', 'C-SWAP', 'Bob Doe', 'swap')
 

--- a/integration-tests/integration/cellMove/considerRisks.cy.js
+++ b/integration-tests/integration/cellMove/considerRisks.cy.js
@@ -1,5 +1,8 @@
 const ConsiderRisksPage = require('../../pages/cellMove/considerRisksPage')
 const ConfirmCellMovePage = require('../../pages/cellMove/confirmCellMovePage')
+const SelectCellPage = require('../../pages/cellMove/selectCellPage')
+const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
+const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 
 const offenderNo = 'A1234A'
 
@@ -379,5 +382,96 @@ context('A user can see conflicts in cell', () => {
     const page = ConsiderRisksPage.goTo(offenderNo, 1)
     page.csraMessages().should('not.exist')
     page.form().confirmationInput().contains('Are you sure you want to select this cell?')
+  })
+
+  describe('back button', () => {
+    const response = [
+      {
+        attributes: [
+          { description: 'Special Cell', code: 'SPC' },
+          { description: 'Gated Cell', code: 'GC' },
+        ],
+        capacity: 2,
+        description: 'MDI-1-2',
+        id: 1,
+        noOfOccupants: 2,
+        userDescription: 'MDI-1-1',
+      },
+      {
+        attributes: [
+          { code: 'LC', description: 'Listener Cell' },
+          { description: 'Gated Cell', code: 'GC' },
+        ],
+        capacity: 3,
+        description: 'MDI-1-1',
+        id: 1,
+        noOfOccupants: 2,
+        userDescription: 'MDI-1-1',
+      },
+    ]
+
+    before(() => {
+      cy.clearCookies()
+      cy.task('resetAndStubTokenVerification')
+      cy.task('stubSignIn', { username: 'ITAG_USER', caseload: 'MDI', roles: ['ROLE_CELL_MOVE'] })
+      cy.signIn()
+    })
+
+    beforeEach(() => {
+      Cypress.Cookies.preserveOnce('hmpps-session-dev')
+      cy.task('stubOffenderBasicDetails', offenderBasicDetails)
+      cy.task('stubOffenderFullDetails', offenderFullDetails)
+      cy.task('stubOffenderNonAssociations', {})
+      cy.task('stubGroups', { id: 'MDI' })
+      cy.task('stubUserCaseLoads')
+      cy.task('stubGroups', { id: 'MDI' })
+      cy.task('stubCellAttributes')
+      cy.task('stubInmatesAtLocation', {
+        inmates: [{ offenderNo: 'A12345', firstName: 'Bob', lastName: 'Doe', assignedLivingUnitId: 1 }],
+      })
+      cy.task('stubGetAlerts', { agencyId: 'MDI', alerts: [{ offenderNo: 'A12345', alertCode: 'PEEP' }] })
+      cy.task('stubCsraAssessments', {
+        offenderNumbers: ['A12345'],
+        assessments: [
+          {
+            offenderNo: 'A12345',
+            assessmentCode: 'CSRA',
+            assessmentDescription: 'CSRA',
+            assessmentComment: 'test',
+            assessmentDate: '2020-01-10',
+            classification: 'Standard',
+            classificationCode: 'STANDARD',
+          },
+        ],
+      })
+      cy.task('stubOffenderNonAssociations', {
+        offenderNo: 'A12345',
+        firstName: 'JOHN',
+        lastName: 'SAUNDERS',
+        agencyDescription: 'MOORLAND (HMP & YOI)',
+        assignedLivingUnitDescription: 'MDI-1-1-015',
+        nonAssociations: [],
+      })
+      cy.task('stubLocation', { locationId: 1, locationData: { parentLocationId: 2, description: 'MDI-1-1' } })
+      cy.task('stubLocation', { locationId: 2, locationData: { parentLocationId: 3 } })
+      cy.task('stubLocation', { locationId: 3, locationData: { locationPrefix: 'MDI-1' } })
+      cy.task('stubUserCaseLoads')
+      cy.task('stubCellsWithCapacity', { cells: response })
+      cy.task('stubCellsWithCapacityByGroupName', { agencyId: 'MDI', groupName: 1, response })
+    })
+
+    context('When referred from the select cell page', () => {
+      beforeEach(() => {
+        SelectCellPage.goTo('A12345', 'ALL')
+        cy.contains('Select an available cell')
+        cy.contains('.govuk-link', 'Select cell').click()
+        cy.contains('You must consider the risks of the prisoners involved')
+      })
+
+      it('should have a back button linking to the prisoner search page', () => {
+        cy.contains('Back').click()
+        cy.contains('Select an available cell')
+      })
+    })
   })
 })

--- a/integration-tests/integration/cellMove/searchForCell.cy.js
+++ b/integration-tests/integration/cellMove/searchForCell.cy.js
@@ -1,7 +1,9 @@
 const moment = require('moment')
+const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const SearchForCellPage = require('../../pages/cellMove/searchForCellPage')
 const OffenderDetailsPage = require('../../pages/cellMove/offenderDetailsPage')
+const SelectCellPage = require('../../pages/cellMove/selectCellPage')
 
 const offenderNo = 'A12345'
 
@@ -176,5 +178,215 @@ context('A user can search for a cell', () => {
       .then((href) => {
         expect(href).to.equal('/prisoner/A12345/cell-move/confirm-cell-move?cellId=C-SWAP')
       })
+  })
+
+  describe('back button', () => {
+    const inmate1 = {
+      bookingId: 1,
+      offenderNo: 'A1234BC',
+      firstName: 'JOHN',
+      lastName: 'SMITH',
+      dateOfBirth: '1990-10-12',
+      age: 29,
+      agencyId: 'MDI',
+      assignedLivingUnitId: 1,
+      assignedLivingUnitDesc: 'UNIT-1',
+      alertsDetails: ['XA', 'XVL'],
+    }
+    const inmate2 = {
+      bookingId: 2,
+      offenderNo: 'B4567CD',
+      firstName: 'STEVE',
+      lastName: 'SMITH',
+      dateOfBirth: '1989-11-12',
+      age: 30,
+      agencyId: 'MDI',
+      assignedLivingUnitId: 2,
+      assignedLivingUnitDesc: 'UNIT-2',
+      alertsDetails: ['RSS', 'XC'],
+    }
+
+    context('When referred from the prisoner search page', () => {
+      beforeEach(() => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.visit(`/change-someones-cell/prisoner-search?keywords=SMITH`)
+      })
+
+      it('should have a back button linking to the previous page', () => {
+        cy.contains('Change cell').click()
+        cy.contains('Search for a cell')
+        cy.contains('Back').click()
+        cy.contains('Search for a prisoner')
+      })
+    })
+
+    context('When referred from the view residential location page', () => {
+      beforeEach(() => {
+        cy.task('stubInmates', {
+          locationId: 'MDI-1',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.visit(`/change-someones-cell/view-residential-location?location=1`)
+      })
+
+      it('should have a back button linking to the previous page', () => {
+        cy.contains('Change cell').click()
+        cy.contains('Search for a cell')
+        cy.contains('Back').click()
+        cy.contains('All prisoners in a residential location')
+      })
+    })
+
+    context('When referred from the cell history page', () => {
+      const history = {
+        history: {
+          content: [
+            {
+              agencyId: 'MDI',
+              assignmentDate: '2020-05-01',
+              assignmentDateTime: '2020-05-01T12:48:33.375',
+              assignmentReason: 'ADM',
+              bookingId: 123,
+              description: 'MDI-1-02',
+              livingUnitId: 1,
+              movementMadeBy: 'STAFF_1',
+            },
+            {
+              agencyId: 'MDI',
+              assignmentDate: '2020-03-01',
+              assignmentDateTime: '2020-03-01T12:48:33.375',
+              assignmentEndDate: '2020-04-01',
+              assignmentEndDateTime: '2020-04-01T12:48:33.375',
+              assignmentReason: 'ADM',
+              bookingId: 123,
+              description: 'MDI-RECP',
+              livingUnitId: 2,
+              movementMadeBy: 'STAFF_2',
+            },
+            {
+              agencyId: 'MDI',
+              assignmentDate: '2020-04-01',
+              assignmentDateTime: '2020-04-01T12:48:33.375',
+              assignmentEndDate: '2020-05-01',
+              assignmentEndDateTime: '2020-05-01T12:48:33.375',
+              assignmentReason: 'ADM',
+              bookingId: 123,
+              description: 'MDI-1-03',
+              livingUnitId: 3,
+              movementMadeBy: 'STAFF_1',
+            },
+          ],
+        },
+      }
+
+      beforeEach(() => {
+        cy.task('stubOffenderBasicDetails', offenderBasicDetails)
+        cy.task('stubAgencyDetails', { agencyId: 'MDI', details: { agencyId: 'MDI', description: 'Moorland' } })
+        cy.task('stubInmatesAtLocation', {
+          inmates: [{ offenderNo: 'A1235A', firstName: 'Test', lastName: 'Offender' }],
+        })
+        cy.task('stubOffenderCellHistory', history)
+        cy.task('stubStaff', {
+          staffId: 'STAFF_1',
+          details: { firstName: 'Staff', lastName: 'One', username: 'STAFF_1' },
+        })
+        cy.task('stubStaff', {
+          staffId: 'STAFF_2',
+          details: { firstName: 'Staff', lastName: 'Two', username: 'STAFF_2' },
+        })
+        cy.visit(`/prisoner/${inmate1.offenderNo}/cell-history`)
+      })
+
+      it('should have a back button linking to the previous page', () => {
+        cy.contains('Change cell').click()
+        cy.contains('Search for a cell')
+        cy.contains('Back').click()
+        cy.contains('John Smith\u2019s location details')
+      })
+    })
+
+    context('When the user clicked back from the select cell page', () => {
+      const response = [
+        {
+          attributes: [
+            { description: 'Special Cell', code: 'SPC' },
+            { description: 'Gated Cell', code: 'GC' },
+          ],
+          capacity: 2,
+          description: 'LEI-1-2',
+          id: 1,
+          noOfOccupants: 2,
+          userDescription: 'LEI-1-1',
+        },
+        {
+          attributes: [
+            { code: 'LC', description: 'Listener Cell' },
+            { description: 'Gated Cell', code: 'GC' },
+          ],
+          capacity: 3,
+          description: 'LEI-1-1',
+          id: 1,
+          noOfOccupants: 2,
+          userDescription: 'LEI-1-1',
+        },
+      ]
+
+      beforeEach(() => {
+        cy.task('stubInmates', {
+          locationId: 'MDI',
+          count: 2,
+          data: [inmate1, inmate2],
+        })
+        cy.task('stubGroups', { id: 'MDI' })
+        cy.task('stubCellAttributes')
+        cy.task('stubInmatesAtLocation', {
+          inmates: [{ offenderNo: 'A12345', firstName: 'Bob', lastName: 'Doe', assignedLivingUnitId: 1 }],
+        })
+        cy.task('stubGetAlerts', { agencyId: 'MDI', alerts: [{ offenderNo: 'A12345', alertCode: 'PEEP' }] })
+        cy.task('stubCsraAssessments', {
+          offenderNumbers: ['A12345'],
+          assessments: [
+            {
+              offenderNo: 'A12345',
+              assessmentCode: 'CSRA',
+              assessmentDescription: 'CSRA',
+              assessmentComment: 'test',
+              assessmentDate: '2020-01-10',
+              classification: 'Standard',
+              classificationCode: 'STANDARD',
+            },
+          ],
+        })
+        cy.task('stubOffenderNonAssociations', {
+          offenderNo: 'G6123VU',
+          firstName: 'JOHN',
+          lastName: 'SAUNDERS',
+          agencyDescription: 'MOORLAND (HMP & YOI)',
+          assignedLivingUnitDescription: 'MDI-1-1-015',
+          nonAssociations: [],
+        })
+        cy.task('stubLocation', { locationId: 1, locationData: { parentLocationId: 2, description: 'MDI-1-1' } })
+        cy.task('stubLocation', { locationId: 2, locationData: { parentLocationId: 3 } })
+        cy.task('stubLocation', { locationId: 3, locationData: { locationPrefix: 'MDI-1' } })
+        cy.task('stubUserCaseLoads')
+        cy.task('stubCellsWithCapacity', { cells: response })
+        cy.task('stubCellsWithCapacityByGroupName', { agencyId: 'MDI', groupName: 1, response })
+
+        SelectCellPage.goTo(inmate1.offenderNo)
+        cy.contains('Select an available cell')
+        cy.contains('Back').click()
+        cy.contains('Search for a cell')
+      })
+
+      it('should have a back button linking to the prisoner search page', () => {
+        cy.contains('Back').click()
+        cy.contains('Search for a prisoner')
+      })
+    })
   })
 })

--- a/integration-tests/integration/cellMove/selectCell.cy.js
+++ b/integration-tests/integration/cellMove/selectCell.cy.js
@@ -1,6 +1,7 @@
 const moment = require('moment')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const SelectCellPage = require('../../pages/cellMove/selectCellPage')
+const ConsiderRisksPage = require('../../pages/cellMove/considerRisksPage')
 
 const offenderNo = 'A12345'
 
@@ -271,6 +272,57 @@ context('A user can select a cell', () => {
 
       page.checkStillOnPage()
       page.noResultsMessage().contains('There are no results for what you have chosen.')
+    })
+
+    describe('back button', () => {
+      context('When referred from the search for a cell page', () => {
+        beforeEach(() => {
+          cy.task('stubOffenderFullDetails', offenderFullDetails)
+          cy.task('stubOffenderNonAssociations', {})
+          cy.task('stubGroups', { id: 'MDI' })
+          cy.task('stubUserCaseLoads')
+          cy.visit('/prisoner/A12345/cell-move/search-for-cell')
+        })
+
+        it('should have a back button linking to the search for a cell page', () => {
+          cy.contains('button', 'Search for a cell').click()
+          cy.contains('Select an available cell')
+          cy.contains('Back').click()
+          cy.contains('Search for a cell')
+        })
+      })
+
+      context('When the user clicked back from the consider risks page', () => {
+        beforeEach(() => {
+          cy.task('stubOffenderFullDetails', offenderFullDetails)
+          cy.task('stubOffenderNonAssociations', {})
+          cy.task('stubGroups', { id: 'MDI' })
+          cy.task('stubUserCaseLoads')
+          cy.task('stubLocation', { locationId: 1, locationData: { parentLocationId: 2, description: 'MDI-1-1' } })
+          cy.task('stubLocation', { locationId: 2, locationData: { parentLocationId: 3 } })
+          cy.task('stubLocation', { locationId: 3, locationData: { locationPrefix: 'MDI-1' } })
+          cy.task('stubInmatesAtLocation', {
+            inmates: [{ offenderNo: 'A12345', firstName: 'Bob', lastName: 'Doe', assignedLivingUnitId: 1 }],
+          })
+          cy.task('stubOffenderNonAssociations', {
+            offenderNo,
+            firstName: 'JOHN',
+            lastName: 'SAUNDERS',
+            agencyDescription: 'MOORLAND (HMP & YOI)',
+            assignedLivingUnitDescription: 'MDI-1-1-015',
+            nonAssociations: [],
+          })
+
+          ConsiderRisksPage.goTo(offenderNo, 1)
+          cy.contains('Back').click()
+          cy.contains('Select an available cell')
+        })
+
+        it('should have a back button linking to the search for a cell page', () => {
+          cy.contains('Back').click()
+          cy.contains('Search for a cell')
+        })
+      })
     })
   })
 })

--- a/views/cellMove/confirmCellMove.njk
+++ b/views/cellMove/confirmCellMove.njk
@@ -4,29 +4,19 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set title = "Confirm cell move" %}
 
 {% block beforeContent %}
-    {{ govukBreadcrumbs({
-        items: [
-            {
-                text: "Home",
-                href: '/'
-            },
-            {
-                text: breadcrumbPrisonerName,
-                href: '/prisoner/' + offenderNo
-            },
-            {
-                text: 'Select cell',
-                href:  '/prisoner/' + offenderNo + '/cell-move/select-cell'
-            },
-            {
-                text: 'Confirm cell move'
-            }
-        ]
+
+  {% if backLink %}
+    {{ govukBackLink({
+      text: "Back",
+      href: backLink
     }) }}
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/views/cellMove/considerRisks.njk
+++ b/views/cellMove/considerRisks.njk
@@ -7,6 +7,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% set title = "You must consider the risks of the prisoners involved" %}
@@ -17,25 +18,14 @@
 {% endmacro %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-      items: [
-          {
-              text: "Home",
-              href: '/'
-          },
-          {
-              text: prisonerNameForBreadcrumb,
-              href: profileUrl
-          },
-          {
-              text: 'Select cell',
-              href: selectCellUrl
-          },
-          {
-              text: "Consider risks"
-          }
-      ]
-  }) }}
+
+  {% if backUrl %}
+    {{ govukBackLink({
+      text: "Back",
+      href: backUrl
+    }) }}
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/views/cellMove/searchForCell.njk
+++ b/views/cellMove/searchForCell.njk
@@ -2,30 +2,20 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../macros/alertFlags.njk" import alertFlags %}
 
 {% set title = "Search for a cell" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Home",
-        href: '/'
-      },
-      {
-        text: breadcrumbPrisonerName,
-        href: profileUrl
-      },
-      {
-        text: 'Location details',
-        href: profileUrl + '/cell-history'
-      },
-      {
-        text: title
-      }
-    ]
-}) }}
+
+  {% if backUrl %}
+    {{ govukBackLink({
+      text: "Back",
+      href: backUrl
+    }) }}
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/views/cellMove/selectCell.njk
+++ b/views/cellMove/selectCell.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "../macros/alertFlags.njk" import alertFlags %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set title = "Select an available cell" %}
 
@@ -76,21 +77,14 @@
 {% endmacro %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Home",
-        href: '/'
-      },
-      {
-        text: breadcrumbPrisonerName,
-        href: '/prisoner/' + offenderNo
-      },
-      {
-        text: 'Select cell'
-      }
-    ]
-}) }}
+
+  {% if backUrl %}
+    {{ govukBackLink({
+      text: "Back",
+      href: backUrl
+    }) }}
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
What?

- Change breadcrumbs to back links on cell moves main journey pages

Why?

- To conform with new DPS breadcrumb guidelines

Ticket

- https://dsdmoj.atlassian.net/browse/MAP-246