### PR TITLE
NON-261: non-associations private beta - Part 2

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,7 +24,7 @@ generic-service:
    CHECK_MY_DIARY_URL: https://check-my-diary-preprod.prison.service.justice.gov.uk?fromDPS=true
    INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api-preprod.hmpps.service.justice.gov.uk
-   NON_ASSOCIATIONS_PRISONS: "LGI,FNI,ISI,RSI"
+   NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
    NON_ASSOCIATIONS_API_ENDPOINT_URL: https://non-associations-api-preprod.hmpps.service.justice.gov.uk
    NON_ASSOCIATIONS_UI_URL: https://non-associations-preprod.hmpps.service.justice.gov.uk
    TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -35,7 +35,7 @@ generic-service:
    PIN_PHONES_URL: https://pcms-qa.prison.service.justice.gov.uk/
    SOC_UI_URL: https://manage-soc-cases-preprod.hmpps.service.justice.gov.uk/
    SOC_API_URL: https://manage-soc-cases-api-preprod.hmpps.service.justice.gov.uk/
-   OFFENDER_SEARCH_API_URL: https://prisoner-offender-search-preprod.prison.service.justice.gov.uk
+   OFFENDER_SEARCH_API_URL: https://prisoner-search-preprod.prison.service.justice.gov.uk
    SUPPORT_URL: https://support-preprod.hmpps.service.justice.gov.uk/
    SYSTEM_PHASE: PRE-PRODUCTION
    BVL_URL: https://book-video-link-preprod.prison.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,7 @@ generic-service:
    CHECK_MY_DIARY_URL: https://checkmydiary.service.justice.gov.uk?fromDPS=true
    INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api.hmpps.service.justice.gov.uk
-   NON_ASSOCIATIONS_PRISONS: "ISI"
+   NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
    NON_ASSOCIATIONS_API_ENDPOINT_URL: https://non-associations-api.hmpps.service.justice.gov.uk
    NON_ASSOCIATIONS_UI_URL: https://non-associations.hmpps.service.justice.gov.uk
    TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,7 @@ generic-service:
    CHECK_MY_DIARY_URL: https://checkmydiary.service.justice.gov.uk?fromDPS=true
    INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
    INCENTIVES_API_ENDPOINT_URL: https://incentives-api.hmpps.service.justice.gov.uk
-   NON_ASSOCIATIONS_PRISONS: ""
+   NON_ASSOCIATIONS_PRISONS: "ISI"
    NON_ASSOCIATIONS_API_ENDPOINT_URL: https://non-associations-api.hmpps.service.justice.gov.uk
    NON_ASSOCIATIONS_UI_URL: https://non-associations.hmpps.service.justice.gov.uk
    TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk


### PR DESCRIPTION
Enable non-association links from prisoner profile in the other 3 private beta prisons (FNI,LGI,RSI)

This PR follows: https://github.com/ministryofjustice/digital-prison-services/pull/2575

**NOTE**: This cannot be merged/released until we go live in these private beta prisons. We'll leave it as a draft PR for the time being.