### PR TITLE
Map 290 dps reception full page

### DIFF
--- a/backend/controllers/receptionMove/considerRisksReception.ts
+++ b/backend/controllers/receptionMove/considerRisksReception.ts
@@ -18,6 +18,14 @@ export default ({ oauthApi, prisonApi, movementsService, nonAssociationsApi, log
         prisonApi.getCsraAssessments(res.locals, [offenderNo]),
       ])
 
+      const receptionOccupancy = await prisonApi.getReceptionsWithCapacity(res.locals, prisonerDetails.agencyId)
+      const { capacity, noOfOccupants } = receptionOccupancy[0]
+
+      if (noOfOccupants >= capacity) {
+        logger.info('Can not move to reception as already full to capacity')
+        return res.redirect(`/prisoner/${offenderNo}/reception-move/reception-full`)
+      }
+
       if (!userHasAccess({ userRoles, userCaseLoads, offenderCaseload: prisonerDetails.agencyId })) {
         logger.info('User does not have correct roles')
         return res.render('notFound.njk', { url: '/prisoner-search' })

--- a/backend/controllers/receptionMove/receptionFull.ts
+++ b/backend/controllers/receptionMove/receptionFull.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express'
+import { formatName } from '../../utils'
+
+export default (prisonApi) => {
+  const view = async (req: Request, res: Response) => {
+    const { offenderNo } = req.params
+    const { firstName, lastName } = await prisonApi.getDetails(res.locals, offenderNo, false)
+    const data = {
+      offenderName: formatName(firstName, lastName),
+      offenderNo,
+      backUrl: req.headers.referer,
+    }
+
+    return res.render('receptionMoves/receptionFull.njk', data)
+  }
+
+  return { view }
+}

--- a/backend/routes/receptionMoveRouter.ts
+++ b/backend/routes/receptionMoveRouter.ts
@@ -1,20 +1,26 @@
 import express from 'express'
 import considerRisksController from '../controllers/receptionMove/considerRisksReception'
+import receptionFullController from '../controllers/receptionMove/receptionFull'
+
 import { movementsServiceFactory } from '../services/movementsService'
 
 const router = express.Router({ mergeParams: true })
 
 const controller = ({ oauthApi, prisonApi, systemOauthClient, incentivesApi, nonAssociationsApi, logError }) => {
   const movementsService = movementsServiceFactory(prisonApi, systemOauthClient, incentivesApi)
-  const { view, submit } = considerRisksController({
+
+  const { view: considerRiskView, submit: considerRiskSubmit } = considerRisksController({
     oauthApi,
     prisonApi,
     movementsService,
     nonAssociationsApi,
     logError,
   })
-  router.get('/consider-risks-reception', view)
-  router.post('/consider-risks-reception', submit)
+  router.get('/consider-risks-reception', considerRiskView)
+  router.post('/consider-risks-reception', considerRiskSubmit)
+
+  const { view: receptionFullView } = receptionFullController(prisonApi)
+  router.get('/reception-full', receptionFullView)
 
   return router
 }

--- a/backend/tests/receptionMove/receptionFullController.test.ts
+++ b/backend/tests/receptionMove/receptionFullController.test.ts
@@ -1,0 +1,54 @@
+import receptionFullController from '../../controllers/receptionMove/receptionFull'
+
+const someOffenderNumber = 'A12345'
+
+const prisonApi = {
+  getDetails: jest.fn(),
+}
+
+const res = { locals: { homeUrl: `prisoner/${someOffenderNumber}` }, redirect: jest.fn(), render: jest.fn() }
+let req
+let controller
+
+describe('Reception full', () => {
+  beforeEach(() => {
+    prisonApi.getDetails.mockResolvedValue({
+      offenderNo: someOffenderNumber,
+      firstName: 'John ',
+      lastName: 'Doe',
+    })
+
+    req = {
+      headers: { referer: 'refering-url' },
+      params: {
+        offenderNo: someOffenderNumber,
+      },
+    }
+
+    controller = receptionFullController(prisonApi)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('page', () => {
+    it('should make the correct api calls', async () => {
+      await controller.view(req, res)
+      expect(prisonApi.getDetails).toHaveBeenCalledWith(
+        { homeUrl: `prisoner/${someOffenderNumber}` },
+        someOffenderNumber,
+        false
+      )
+    })
+
+    it('should render with correct data', async () => {
+      await controller.view(req, res)
+      expect(res.render).toHaveBeenCalledWith('receptionMoves/receptionFull.njk', {
+        offenderName: 'John  Doe',
+        offenderNo: 'A12345',
+        backUrl: 'refering-url',
+      })
+    })
+  })
+})

--- a/backend/tests/receptionMove/receptionFullController.test.ts
+++ b/backend/tests/receptionMove/receptionFullController.test.ts
@@ -6,7 +6,7 @@ const prisonApi = {
   getDetails: jest.fn(),
 }
 
-const res = { locals: { homeUrl: `prisoner/${someOffenderNumber}` }, redirect: jest.fn(), render: jest.fn() }
+const res = { locals: {}, redirect: jest.fn(), render: jest.fn() }
 let req
 let controller
 
@@ -35,11 +35,7 @@ describe('Reception full', () => {
   describe('page', () => {
     it('should make the correct api calls', async () => {
       await controller.view(req, res)
-      expect(prisonApi.getDetails).toHaveBeenCalledWith(
-        { homeUrl: `prisoner/${someOffenderNumber}` },
-        someOffenderNumber,
-        false
-      )
+      expect(prisonApi.getDetails).toHaveBeenCalledWith({}, someOffenderNumber, false)
     })
 
     it('should render with correct data', async () => {

--- a/views/partials/layout.njk
+++ b/views/partials/layout.njk
@@ -9,6 +9,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "govuk/template.njk" %}
 

--- a/views/receptionMoves/receptionFull.njk
+++ b/views/receptionMoves/receptionFull.njk
@@ -1,0 +1,27 @@
+{% extends "../partials/layout.njk" %}
+
+{% set title = "No space available in reception" %}
+
+{% block beforeContent %}
+  {% if backUrl %}
+    {{ govukBackLink({
+      text: "Back",
+      href: backUrl
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"> {{title}} </h1>
+      <p class="govuk-body"> You can't move this person to reception as it is currently at full capacity. </p>
+      <p class="govuk-body"> You should contact reception to see if a space can be made available. </p>
+      <p class="govuk-body">
+        <a href="/prisoner/{{offenderNo}}/location-details" class="govuk-link" data-test="location-details-link">
+          Return to {{ offenderName }}'s location details 
+        </a>
+      </p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
user redirected to /reception-moves/reception-full if there is no room in reception when they try to get to /reception-move/consider-risks-reception

The backlink in /reception-moves/reception-full not displayed if the user navigate's to page by adding url to search bar directly. 