### PR TITLE
MAP-290 fix logic that determines reception capacity

### DIFF
--- a/backend/controllers/receptionMove/considerRisksReception.ts
+++ b/backend/controllers/receptionMove/considerRisksReception.ts
@@ -19,9 +19,8 @@ export default ({ oauthApi, prisonApi, movementsService, nonAssociationsApi, log
       ])
 
       const receptionOccupancy = await prisonApi.getReceptionsWithCapacity(res.locals, prisonerDetails.agencyId)
-      const { capacity, noOfOccupants } = receptionOccupancy[0]
 
-      if (noOfOccupants >= capacity) {
+      if (!receptionOccupancy.length) {
         logger.info('Can not move to reception as already full to capacity')
         return res.redirect(`/prisoner/${offenderNo}/reception-move/reception-full`)
       }

--- a/backend/tests/receptionMove/considerRisksReceptionController.test.ts
+++ b/backend/tests/receptionMove/considerRisksReceptionController.test.ts
@@ -111,12 +111,7 @@ describe('Consider risks reception', () => {
 
     it('should redirect if reception already full', async () => {
       req.body = { considerRisksReception: 'yes' }
-      prisonApi.getReceptionsWithCapacity.mockResolvedValue([
-        {
-          capacity: 10,
-          noOfOccupants: 10,
-        },
-      ])
+      prisonApi.getReceptionsWithCapacity.mockResolvedValue([])
       await controller.view(req, res)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoner/${someOffenderNumber}/reception-move/reception-full`)
       expect(logger.info).toBeCalledWith('Can not move to reception as already full to capacity')


### PR DESCRIPTION
corrected logic to display the reception-full page.
prisonApi.getReceptionsWithCapacity returns an empty array if there is no capacity so previous logic was attempting to destruct a null object