### PR TITLE
SDIT-1384 StaffResource - catch access error

### DIFF
--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -298,7 +298,17 @@ export const prisonApiFactory = (client) => {
 
   const getMainOffence = (context, bookingId) => get(context, `/api/bookings/${bookingId}/mainOffence`)
 
-  const getStaffRoles = (context, staffId, agencyId) => get(context, `/api/staff/${staffId}/${agencyId}/roles`)
+  const getStaffRoles = async (context, staffId, agencyId) => {
+    try {
+      return await get(context, `/api/staff/${staffId}/${agencyId}/roles`)
+    } catch (error) {
+      if (error.status === 403) {
+        // can happen for CADM (central admin) users
+        return []
+      }
+      throw error
+    }
+  }
 
   const getPrisonerBalances = (context, bookingId) => get(context, `/api/bookings/${bookingId}/balances`)
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -289,7 +289,6 @@ module.exports = defineConfig({
           healthTypes,
           careNeeds,
           reasonableAdjustments,
-          agencies,
           prisonOffenderManagers,
           neurodiversities,
           neurodivergence,
@@ -525,7 +524,7 @@ module.exports = defineConfig({
         stubGetCellMoveReason: ({ bookingId, bedAssignmentHistorySequence, cellMoveReason, status }) =>
           whereabouts.stubGetCellMoveReason(bookingId, bedAssignmentHistorySequence, cellMoveReason, status),
         stubGetStaffDetails: ({ staffId, response }) => prisonApi.stubGetStaffDetails(staffId, response),
-        stubStaffRoles: (response) => prisonApi.stubStaffRoles(response),
+        stubStaffRoles: ({ response, status }) => prisonApi.stubStaffRoles(response, status),
         stubLocationConfig: ({ agencyId, response }) => whereabouts.stubLocationConfig({ agencyId, response }),
         stubGetDetailsFailure: ({ status }) => prisonApi.stubGetDetailsFailure(status),
         stubGetPrisoners: (response) => prisonApi.stubGetPrisoners(response),

--- a/integration-tests/integration/commonComponents.cy.js
+++ b/integration-tests/integration/commonComponents.cy.js
@@ -1,4 +1,3 @@
-const HomePage = require('../pages/homepage/homepagePage')
 const homepagePage = require('../pages/homepage/homepagePage')
 
 context('Common component functionality', () => {
@@ -9,7 +8,7 @@ context('Common component functionality', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubUserLocations')
-    cy.task('stubStaffRoles', [])
+    cy.task('stubStaffRoles', { roles: [] })
     cy.task('stubLocationConfig', { agencyId: 'MDI', response: { enabled: false } })
     cy.task('stubKeyworkerMigrated')
     cy.task('stubComponents')

--- a/integration-tests/integration/homepage/homepage.cy.js
+++ b/integration-tests/integration/homepage/homepage.cy.js
@@ -5,7 +5,7 @@ context('Homepage', () => {
     cy.clearCookies()
     cy.task('reset')
     cy.task('stubUserLocations')
-    cy.task('stubStaffRoles', [])
+    cy.task('stubStaffRoles', { roles: [] })
     cy.task('stubLocationConfig', { agencyId: 'MDI', response: { enabled: false } })
     cy.task('stubKeyworkerMigrated')
   })

--- a/integration-tests/integration/signIn/signIn.cy.js
+++ b/integration-tests/integration/signIn/signIn.cy.js
@@ -8,7 +8,7 @@ context('Sign in functionality', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubUserLocations')
-    cy.task('stubStaffRoles', [])
+    cy.task('stubStaffRoles', { roles: [] })
     cy.task('stubLocationConfig', { agencyId: 'MDI', response: { enabled: false } })
     cy.task('stubKeyworkerMigrated')
     cy.task('stubComponentsFail')
@@ -44,6 +44,16 @@ context('Sign in functionality', () => {
 
   it('Sign in takes user to sign in page', () => {
     cy.task('stubSignIn', {})
+    cy.signIn()
+    HomePage.verifyOnPage()
+
+    // can't do a visit here as cypress requires only one domain
+    cy.request('/auth/sign-out').its('body').should('contain', 'Sign in')
+  })
+
+  it('Page shown when roles are unauthorised', () => {
+    cy.task('stubSignIn', {})
+    cy.task('stubStaffRoles', { roles: [], status: 403 })
     cy.signIn()
     HomePage.verifyOnPage()
 

--- a/integration-tests/mockApis/prisonApi.js
+++ b/integration-tests/mockApis/prisonApi.js
@@ -316,14 +316,14 @@ module.exports = {
         jsonBody: summary || [],
       },
     }),
-  stubStaffRoles: (roles) =>
+  stubStaffRoles: (roles, status) =>
     stubFor({
       request: {
         method: 'GET',
         urlPattern: `/api/staff/.+?/.+?/roles`,
       },
       response: {
-        status: 200,
+        status: status || 200,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },


### PR DESCRIPTION
Now that the prison-api endpoint has been protected with a role, some scenarios will fail