### PR TITLE
SDIT-1384 StaffResource - catch access error

### DIFF
--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -302,7 +302,7 @@ export const prisonApiFactory = (client) => {
     try {
       return await get(context, `/api/staff/${staffId}/${agencyId}/roles`)
     } catch (error) {
-      if (error.status === 403) {
+      if (error.status === 403 || error.status === 404) {
         // can happen for CADM (central admin) users
         return []
       }

--- a/integration-tests/integration/signIn/signIn.cy.js
+++ b/integration-tests/integration/signIn/signIn.cy.js
@@ -61,6 +61,16 @@ context('Sign in functionality', () => {
     cy.request('/auth/sign-out').its('body').should('contain', 'Sign in')
   })
 
+  it('Page shown when roles are not found', () => {
+    cy.task('stubSignIn', {})
+    cy.task('stubStaffRoles', { roles: [], status: 404 })
+    cy.signIn()
+    HomePage.verifyOnPage()
+
+    // can't do a visit here as cypress requires only one domain
+    cy.request('/auth/sign-out').its('body').should('contain', 'Sign in')
+  })
+
   it('Token verification failure takes user to sign in page', () => {
     cy.task('stubSignIn', {})
     cy.signIn()


### PR DESCRIPTION
A tweak to an earlier change allowing for errors from prison-api endpoint which checks what roles the current user has. This endpoint now enforces tighter restrictions so can reject calls from CADMs (who may not have a relevant caseload)