### PR TITLE
MAP-664 bugfix

### DIFF
--- a/backend/controllers/receptionMove/confirmReceptionMove.ts
+++ b/backend/controllers/receptionMove/confirmReceptionMove.ts
@@ -98,6 +98,9 @@ export default ({ prisonApi, whereaboutsApi }) => {
         commentText: comment,
       })
 
+      // just to remove formValues out of flash to prevent being consumed in /cell-move/confirm-cell-move
+      req.flash('formValues')
+
       return res.redirect(`/prisoner/${offenderNo}/reception-move/confirmation`)
     } catch (error) {
       logger.error(`Error moving ${offenderNo} to reception`)

--- a/backend/controllers/receptionMove/considerRisksReception.ts
+++ b/backend/controllers/receptionMove/considerRisksReception.ts
@@ -123,6 +123,9 @@ export default ({ oauthApi, prisonApi, movementsService, nonAssociationsApi, log
         comment: nonAssociation.comments || 'Not entered',
       }))
 
+      const personOrPeople = otherOffenders.length === 1 ? 'person' : 'people'
+      const inReceptionCount = `${otherOffenders.length} ${personOrPeople} in reception`
+
       return res.render('receptionMoves/considerRisksReception.njk', {
         reverseOrderPrisonerName: putLastNameFirst(prisonerDetails.firstName, prisonerDetails.lastName).trim(),
         prisonerName: formatName(prisonerDetails.firstName, prisonerDetails.lastName),
@@ -138,7 +141,7 @@ export default ({ oauthApi, prisonApi, movementsService, nonAssociationsApi, log
         hasNonAssociations: nonAssociationsInEstablishment?.length > 0,
         nonAssociationsRows,
         offendersInReception: otherOffenders,
-        inReceptionCount: `${otherOffenders.length} people in reception`,
+        inReceptionCount,
         errors: req.flash('errors'),
       })
     } catch (error) {

--- a/backend/tests/receptionMove/confirmReceptionMoveController.test.ts
+++ b/backend/tests/receptionMove/confirmReceptionMoveController.test.ts
@@ -248,7 +248,7 @@ describe('Confirm reception move', () => {
 
       await controller.post(req, res)
 
-      expect(req.flash).toHaveBeenCalledTimes(1)
+      expect(req.flash).toHaveBeenCalledTimes(2)
       expect(res.redirect).toBeCalledWith('/prisoner/A12345/reception-move/confirmation')
     })
 

--- a/backend/tests/receptionMove/considerRisksReceptionController.test.ts
+++ b/backend/tests/receptionMove/considerRisksReceptionController.test.ts
@@ -164,7 +164,36 @@ describe('Consider risks reception', () => {
         })
       )
     })
-    it('should populate view model with other prisoners in reception', async () => {
+    it('should populate view model with correct text for one prisoners in reception', async () => {
+      movementsService.getOffendersInReception.mockResolvedValue([
+        {
+          offenderNo: 'A123',
+          firstName: 'Max',
+          lastName: 'Mercedes',
+
+          alerts: [],
+        },
+      ])
+      await controller.view(req, res)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'receptionMoves/considerRisksReception.njk',
+        expect.objectContaining({
+          inReceptionCount: '1 person in reception',
+          offendersInReception: [
+            {
+              alerts: [],
+              csraClassification: 'Not entered',
+              displayCsraLink: undefined,
+              name: 'Mercedes, Max',
+              nonAssociation: false,
+              offenderNo: 'A123',
+            },
+          ],
+        })
+      )
+    })
+    it('should populate view model with other prisoners correctly when more than 1 prisoner in reception', async () => {
       movementsService.getOffendersInReception.mockResolvedValue([
         {
           offenderNo: 'A123',


### PR DESCRIPTION
1. content change on reception-move/consider-risks-reception page. If only one prisoner in reception, should show ‘1 person in reception’. Otherwise should display   ‘ x people in reception’ 

 2. when moving prisoner from cell to reception then back from reception to cell again, the app currently persists the radio selection button selected and the comments entered in the  confirmation pages. These should not be carried over. i.e cell-move/confirm-cell-move should not present any selections or comments that were set in /reception-move/confirm-reception-move
