### PR TITLE
[MAP-916] Update Change Someone's Cell link in Establisment Roll

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -247,6 +247,9 @@ export const apis = {
     timeoutSeconds: toNumber(process.env.COMPONENT_API_TIMEOUT_SECONDS) || 5,
     latestFeatures: process.env.COMPONENT_API_LATEST === 'true',
   },
+  changeSomeonesCell: {
+    ui_url: process.env.CHANGE_SOMEONES_CELL_URL || 'http://localhost:3002',
+  },
 }
 export const notifications = {
   enabled: process.env.NOTIFY_ENABLED ? process.env.NOTIFY_ENABLED === 'true' : true,

--- a/backend/controllers/establishmentRoll/noCellAllocated.ts
+++ b/backend/controllers/establishmentRoll/noCellAllocated.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import { formatName, putLastNameFirst, getTime, stripAgencyPrefix } from '../../utils'
+import config from '../../config'
 
 export default ({ oauthApi, systemOauthClient, prisonApi }) =>
   async (req: Partial<Request>, res: Partial<Response>) => {
@@ -70,6 +71,7 @@ export default ({ oauthApi, systemOauthClient, prisonApi }) =>
             previousCell: stripAgencyPrefix(previousLocation.description, activeCaseLoad.caseLoadId),
             name: putLastNameFirst(prisonerDetails.firstName, prisonerDetails.lastName),
             timeOut: getTime(previousLocation.assignmentEndDateTime),
+            allocateCellUrl: `${config.apis.changeSomeonesCell.ui_url}/prisoner/${offenderNo}/cell-move/search-for-cell`,
           }
         }),
         userCanAllocateCell: userRoles?.some((role) => role.roleCode === 'CELL_MOVE'),

--- a/backend/tests/establishmentRoll/noCellAllocated.test.ts
+++ b/backend/tests/establishmentRoll/noCellAllocated.test.ts
@@ -173,6 +173,7 @@ describe('No cell allocated', () => {
             offenderNo: 'A7777DY',
             previousCell: 'RECP',
             timeOut: '16:56',
+            allocateCellUrl: 'http://localhost:3002/prisoner/A7777DY/cell-move/search-for-cell',
           },
         ],
         userCanAllocateCell: true,

--- a/cypress.env
+++ b/cypress.env
@@ -68,3 +68,4 @@ MANAGE_OFFENCES_URL=https://manage-offences
 MANAGE_ADJUDICATIONS_API_URL=http://localhost:9191/adjudications/
 
 COMPONENT_API_URL=http://localhost:9191/components
+CHANGE_SOMEONES_CELL_URL=http://change-someones-cell

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -88,3 +88,4 @@ generic-service:
    PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk
    PRISONER_PROFILE_REDIRECT_EXEMPTIONS: ""
    HOMEPAGE_REDIRECT_EXEMPTIONS: ""
+   CHANGE_SOMEONES_CELL_URL: https://change-someones-cell-dev.prison.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -85,6 +85,7 @@ generic-service:
     PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui-preprod.hmpps.service.justice.gov.uk
     PRISONER_PROFILE_REDIRECT_EXEMPTIONS: ""
     HOMEPAGE_REDIRECT_EXEMPTIONS: ""
+    CHANGE_SOMEONES_CELL_URL: https://change-someones-cell-preprod.prison.service.justice.gov.uk
 
   allowlist:
     groups:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -86,6 +86,7 @@ generic-service:
     PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui.hmpps.service.justice.gov.uk
     PRISONER_PROFILE_REDIRECT_EXEMPTIONS: ""
     HOMEPAGE_REDIRECT_EXEMPTIONS: ""
+    CHANGE_SOMEONES_CELL_URL: https://change-someones-cell.prison.service.justice.gov.uk
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/integration-tests/integration/establishmentRollCount/noCellAllocated.cy.js
+++ b/integration-tests/integration/establishmentRollCount/noCellAllocated.cy.js
@@ -185,7 +185,7 @@ context('with permissions', () => {
       cy.get($allocateCellLink).its('length').should('eq', 1)
       cy.get($allocateCellLink.get(0))
         .should('have.attr', 'href')
-        .should('include', '/prisoner/A7777DY/cell-move/search-for-cell')
+        .should('include', 'http://change-someones-cell/prisoner/A7777DY/cell-move/search-for-cell')
     })
   })
 })

--- a/views/establishmentRoll/noCellAllocated.njk
+++ b/views/establishmentRoll/noCellAllocated.njk
@@ -33,7 +33,7 @@
     { text: prisoner.previousCell },
     { text: prisoner.timeOut },
     { text: prisoner.movedBy },
-    { html: '<a href="/prisoner/' + prisoner.offenderNo + '/cell-move/search-for-cell" class="govuk-link" data-test="allocate-cell-link">Allocate cell</a>' } if userCanAllocateCell
+    { html: '<a href="' + prisoner.allocateCellUrl + '" class="govuk-link" data-test="allocate-cell-link">Allocate cell</a>' } if userCanAllocateCell
   ]), rows) %}
 {% endfor %}
 


### PR DESCRIPTION
The "allocate cell" link was still pointing at the old Change Someone's Cell app, which explains why we're still getting traffic there.

[MAP-916]