### PR TITLE
MAP-1411 get prison location groups from locations-inside-prison-api …

### DIFF
--- a/backend/api/locationsInsidePrisonApi.ts
+++ b/backend/api/locationsInsidePrisonApi.ts
@@ -4,6 +4,10 @@ export interface LocationPrefix {
   locationPrefix: string
 }
 
+export interface Location {
+  key: string
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const locationsInsidePrisonApiFactory = (client: OauthApiClient) => {
   const processResponse = () => (response) => response.body
@@ -21,8 +25,12 @@ export const locationsInsidePrisonApiFactory = (client: OauthApiClient) => {
   const getAgencyGroupLocationPrefix = (systemContext, prisonId, group): Promise<LocationPrefix> =>
     getWith404AsNull(systemContext, `/locations/prison/${prisonId}/group/${group}/location-prefix`)
 
+  const getAgencyGroupLocations = (systemContext, prisonId, groupName): Promise<Location> =>
+    getWith404AsNull(systemContext, `/locations/groups/${prisonId}/${groupName}`)
+
   return {
     getAgencyGroupLocationPrefix,
+    getAgencyGroupLocations,
   }
 }
 

--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -98,7 +98,7 @@ export const prisonApiFactory = (client) => {
   const setActiveCaseload = (context, caseload) => put(context, '/api/users/me/activeCaseLoad', caseload)
 
   const getHouseblockList = (context, agencyId, locationIds, date, timeSlot) =>
-    post(context, `/api/schedules/${agencyId}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}`, locationIds)
+    post(context, `/api/schedules/${agencyId}/events-by-location-path?date=${date}&timeSlot=${timeSlot}`, locationIds)
 
   const getActivityList = (context, { agencyId, locationId, usage, date, timeSlot }) =>
     get(

--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -97,8 +97,8 @@ export const prisonApiFactory = (client) => {
   // However, only 'caseLoadId' has meaning.  The other two properties can take *any* non-blank value and these will be ignored.
   const setActiveCaseload = (context, caseload) => put(context, '/api/users/me/activeCaseLoad', caseload)
 
-  const getHouseblockList = (context, agencyId, locationIds, date, timeSlot) =>
-    post(context, `/api/schedules/${agencyId}/events-by-location-path?date=${date}&timeSlot=${timeSlot}`, locationIds)
+  const getHouseblockList = (context, prisonId, locationPaths, date, timeSlot) =>
+    post(context, `/api/schedules/${prisonId}/events-by-location-path?date=${date}&timeSlot=${timeSlot}`, locationPaths)
 
   const getActivityList = (context, { agencyId, locationId, usage, date, timeSlot }) =>
     get(

--- a/backend/api/whereaboutsApi.ts
+++ b/backend/api/whereaboutsApi.ts
@@ -61,9 +61,6 @@ export const whereaboutsApiFactory = (client) => {
 
   const searchGroups = (context, agencyId) => get(context, `/agencies/${agencyId}/locations/groups`)
 
-  const getAgencyGroupLocations = (context, agencyId, groupName) =>
-    get(context, `/locations/groups/${agencyId}/${groupName}`)
-
   const getCourtLocations = (context) => get(context, '/court/courts')
 
   const addVideoLinkBooking = (context, body) => post(context, '/court/video-link-bookings', body)
@@ -126,7 +123,6 @@ export const whereaboutsApiFactory = (client) => {
     getUnacceptableAbsences,
     getUnacceptableAbsenceDetail,
     searchGroups,
-    getAgencyGroupLocations,
     getCourtLocations,
     addVideoLinkBooking,
     getVideoLinkAppointments,

--- a/backend/controllers/attendance/houseblockList.ts
+++ b/backend/controllers/attendance/houseblockList.ts
@@ -69,10 +69,10 @@ export const getHouseblockListFactory = (
       return []
     }
 
-    const locationIds = locations.map((location) => location.pathHierarchy)
+    const locationPaths = locations.map((location) => location.pathHierarchy)
     const formattedDate = switchDateFormat(date)
     // Returns array ordered by inmate/cell or name, then start time
-    const data = await prisonApi.getHouseblockList(context, agencyId, locationIds, formattedDate, timeSlot)
+    const data = await prisonApi.getHouseblockList(context, agencyId, locationPaths, formattedDate, timeSlot)
 
     const offenderNumbers = distinct(data.map((offender) => offender.offenderNo))
 

--- a/backend/controllers/attendance/houseblockList.ts
+++ b/backend/controllers/attendance/houseblockList.ts
@@ -55,14 +55,21 @@ const addToActivities = (offender, activity) => ({
   stayingOnWing: isStayingOnWing([...offender.activities, activity]),
 })
 
-export const getHouseblockListFactory = (getClientCredentialsTokens, prisonApi, whereaboutsApi) => {
+export const getHouseblockListFactory = (
+  getClientCredentialsTokens,
+  prisonApi,
+  whereaboutsApi,
+  locationsInsidePrisonApi
+) => {
   const getHouseblockList = async (context, agencyId, groupName, date, timeSlot, wingStatus) => {
-    const locations = await whereaboutsApi.getAgencyGroupLocations(context, agencyId, groupName)
+    const systemContext = await getClientCredentialsTokens()
+
+    const locations = await locationsInsidePrisonApi.getAgencyGroupLocations(systemContext, agencyId, groupName)
     if (locations.length === 0) {
       return []
     }
 
-    const locationIds = locations.map((location) => location.locationId)
+    const locationIds = locations.map((location) => location.pathHierarchy)
     const formattedDate = switchDateFormat(date)
     // Returns array ordered by inmate/cell or name, then start time
     const data = await prisonApi.getHouseblockList(context, agencyId, locationIds, formattedDate, timeSlot)

--- a/backend/setupApiRoutes.ts
+++ b/backend/setupApiRoutes.ts
@@ -32,6 +32,7 @@ const router = express.Router()
 export const setup = ({
   prisonApi,
   whereaboutsApi,
+  locationsInsidePrisonApi,
   oauthApi,
   getClientCredentialsTokens,
   hmppsManageUsersApi,
@@ -39,7 +40,12 @@ export const setup = ({
 }) => {
   const controller = controllerFactory({
     activityListService: activityListFactory(getClientCredentialsTokens, prisonApi, whereaboutsApi),
-    houseblockListService: houseblockListFactory(getClientCredentialsTokens, prisonApi, whereaboutsApi),
+    houseblockListService: houseblockListFactory(
+      getClientCredentialsTokens,
+      prisonApi,
+      whereaboutsApi,
+      locationsInsidePrisonApi
+    ),
     attendanceService: attendanceFactory(whereaboutsApi),
     offenderLoader: offenderLoaderFactory(prisonApi),
     csvParserService: csvParserService({ fs, isBinaryFileSync }),

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -477,7 +477,7 @@ module.exports = defineConfig({
         stubExternalTransfers: (response) => prisonApi.stubExternalTransfers(response),
         stubAssessments: (offenderNumbers) => prisonApi.stubAssessments(offenderNumbers),
         stubGetAgencyGroupLocations: ({ agencyId, groupName, response }) =>
-          whereabouts.stubGetAgencyGroupLocations({ agencyId, groupName, response }),
+          locationsInsidePrisonApi.stubGetAgencyGroupLocations({ agencyId, groupName, response }),
         stubLocationGroups: (locationGroups) => whereabouts.stubLocationGroups(locationGroups),
         stubActivityLocationsByDateAndPeriod: ({ locations, date, period, withFault }) =>
           prisonApi.stubActivityLocationsByDateAndPeriod(locations, date, period, withFault),

--- a/integration-tests/integration/activity/houseblockList.cy.js
+++ b/integration-tests/integration/activity/houseblockList.cy.js
@@ -141,7 +141,11 @@ context('Houseblock list page list page', () => {
     cy.signIn()
     cy.task('stubGroups', { id: caseload })
     cy.task('stubActivityLocations')
-    cy.task('stubGetAgencyGroupLocations', { agencyId: caseload, groupName: 1, response: [1] })
+    cy.task('stubGetAgencyGroupLocations', {
+      agencyId: caseload,
+      groupName: 1,
+      response: [{ pathHierarchy: 'A-1-1' }],
+    })
     cy.task('stubGetAttendancesForBookings', {
       agencyId: caseload,
       date,

--- a/integration-tests/mockApis/locationsInsidePrisonApi.js
+++ b/integration-tests/mockApis/locationsInsidePrisonApi.js
@@ -29,4 +29,19 @@ module.exports = {
         jsonBody: response,
       },
     }),
+
+  stubGetAgencyGroupLocations: ({ agencyId, groupName, response }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/locations/locations/groups/${agencyId}/${groupName}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: response,
+      },
+    }),
 }

--- a/integration-tests/mockApis/prisonApi.js
+++ b/integration-tests/mockApis/prisonApi.js
@@ -1601,7 +1601,7 @@ module.exports = {
     stubFor({
       request: {
         method: 'POST',
-        url: `/api/schedules/${agencyId}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}`,
+        url: `/api/schedules/${agencyId}/events-by-location-path?date=${date}&timeSlot=${timeSlot}`,
       },
       response: {
         status: 200,

--- a/integration-tests/mockApis/whereabouts.js
+++ b/integration-tests/mockApis/whereabouts.js
@@ -300,20 +300,6 @@ module.exports = {
     })
   },
 
-  stubGetAgencyGroupLocations: ({ agencyId, groupName, response }) =>
-    stubFor({
-      request: {
-        method: 'GET',
-        url: `/whereabouts/locations/groups/${agencyId}/${groupName}`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: response,
-      },
-    }),
   stubCellsWithCapacityByGroupName: ({ agencyId, groupName, response }) =>
     stubFor({
       request: {


### PR DESCRIPTION
…rather than whereabouts-api

See [MAP-1411](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?quickFilter=3684&selectedIssue=MAP-1411)

This code change was to get group locations from the new locationsInsidePrisonApi rather than whereaboutsApi.
The relevant function in whereaboutsApi was getAgencyGroupLocations which was only used in a single place in the codebase, specifically in houseblockList.ts

The call to whereaboutsApi.getAgencyGroupLocations returned the locations with their 'integer' form id's which were then passed prisonApi.getHouseblockList() to get each location's details. 
However locationsInsidePrisonApi.getAgencyGroupLocations() doesn't return the integer from id's so instead the location pathHierarchies (eg 'A-1-1') were extracted and passed to a new prisonApi.getHouseblockList() endpoint that is able to accept pathHierarchies rather than integer form Id's 

[MAP-1411]: https://dsdmoj.atlassian.net/browse/MAP-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ