### PR TITLE
MAP-1287 /select-residential-location to gets groups from locationsApi

### DIFF
--- a/backend/api/locationsInsidePrisonApi.test.ts
+++ b/backend/api/locationsInsidePrisonApi.test.ts
@@ -14,7 +14,7 @@ describe('Locations Inside Prison Api', () => {
     nock.cleanAll()
   })
 
-  describe('/location-prefix', () => {
+  describe('getAgencyGroupLocationPrefix', () => {
     it('Successfully retrieves a location prefix', async () => {
       const mockResponse = {
         locationPrefix: 'MDI-1-',
@@ -58,6 +58,64 @@ describe('Locations Inside Prison Api', () => {
       await expect(
         locationsInsidePrisonApi.getAgencyGroupLocationPrefix({ access_token: accessToken }, 'MDI', 'block-1')
       ).rejects.toThrow('Bad Request')
+    })
+  })
+
+  describe('getAgencyGroupLocations', () => {
+    it('gets group locations correctly', async () => {
+      const mockResponse = {
+        key: 'A',
+        name: 'Wing A',
+        children: [],
+      }
+
+      mock.get('/locations/groups/MDI/1').reply(200, mockResponse)
+      const response = await locationsInsidePrisonApi.getAgencyGroupLocations({}, 'MDI', 1)
+      expect(response).toEqual(mockResponse)
+    })
+
+    it('Returns null when 404 error occurs', async () => {
+      mock.get('/locations/groups/MDI/1').matchHeader('authorization', `Bearer ${accessToken}`).reply(404)
+
+      const response = await locationsInsidePrisonApi.getAgencyGroupLocations({ access_token: accessToken }, 'MDI', '1')
+
+      expect(response).toEqual(null)
+    })
+
+    it('it throws the error', async () => {
+      mock.get('/locations/groups/MDI/1').matchHeader('authorization', `Bearer ${accessToken}`).reply(400)
+
+      await expect(
+        locationsInsidePrisonApi.getAgencyGroupLocations({ access_token: accessToken }, 'MDI', '1')
+      ).rejects.toThrow('Bad Request')
+    })
+  })
+
+  describe('getSearchGroups', () => {
+    it('gets groups correctly', async () => {
+      const mockResponse = {
+        key: 'A',
+        name: 'Wing A',
+        children: [],
+      }
+
+      mock.get('/locations/prison/MDI/groups').reply(200, mockResponse)
+      const response = await locationsInsidePrisonApi.getSearchGroups({ access_token: accessToken }, 'MDI')
+      expect(response).toEqual(mockResponse)
+    })
+    it('Returns null when 404 error occurs', async () => {
+      mock.get('/locations/prison/MDI/groups').matchHeader('authorization', `Bearer ${accessToken}`).reply(404)
+
+      const response = await locationsInsidePrisonApi.getSearchGroups({ access_token: accessToken }, 'MDI')
+      expect(response).toEqual(null)
+    })
+
+    it('it throws the error', async () => {
+      mock.get('/locations/prison/MDI/groups').matchHeader('authorization', `Bearer ${accessToken}`).reply(400)
+
+      await expect(locationsInsidePrisonApi.getSearchGroups({ access_token: accessToken }, 'MDI')).rejects.toThrow(
+        'Bad Request'
+      )
     })
   })
 })

--- a/backend/api/locationsInsidePrisonApi.ts
+++ b/backend/api/locationsInsidePrisonApi.ts
@@ -8,6 +8,15 @@ export interface Location {
   key: string
 }
 
+export interface LocationGroup {
+  name: string
+  key: string
+  children: {
+    key: string
+    name: string
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const locationsInsidePrisonApiFactory = (client: OauthApiClient) => {
   const processResponse = () => (response) => response.body
@@ -25,12 +34,17 @@ export const locationsInsidePrisonApiFactory = (client: OauthApiClient) => {
   const getAgencyGroupLocationPrefix = (systemContext, prisonId, group): Promise<LocationPrefix> =>
     getWith404AsNull(systemContext, `/locations/prison/${prisonId}/group/${group}/location-prefix`)
 
-  const getAgencyGroupLocations = (systemContext, prisonId, groupName): Promise<Location> =>
+  const getAgencyGroupLocations = (systemContext, prisonId, groupName): Promise<Location[]> =>
     getWith404AsNull(systemContext, `/locations/groups/${prisonId}/${groupName}`)
+
+  const getSearchGroups = (context, prisonId): Promise<LocationGroup[]> => {
+    return getWith404AsNull(context, `/locations/prison/${prisonId}/groups`)
+  }
 
   return {
     getAgencyGroupLocationPrefix,
     getAgencyGroupLocations,
+    getSearchGroups,
   }
 }
 

--- a/backend/controllers/selectResidentialLocation.ts
+++ b/backend/controllers/selectResidentialLocation.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import { getCurrentPeriod } from '../utils'
 
-export default (whereaboutsApi) => {
+export default (locationsInsidePrisonApi, systemOauthClient) => {
   const renderTemplate = async (req, res, pageData?) => {
     const today = moment()
     const { errors, formValues } = pageData || {}
@@ -9,7 +9,13 @@ export default (whereaboutsApi) => {
       const {
         user: { activeCaseLoad },
       } = res.locals
-      const residentialLocations = await whereaboutsApi.searchGroups(res.locals, activeCaseLoad.caseLoadId)
+
+      const systemContext = await systemOauthClient.getClientCredentialsTokens(req.session.userDetails.username)
+
+      const residentialLocations = await locationsInsidePrisonApi.getSearchGroups(
+        systemContext,
+        activeCaseLoad.caseLoadId
+      )
 
       return res.render('selectResidentialLocation.njk', {
         date: formValues?.date || today.format('DD/MM/YYYY'),

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -191,12 +191,12 @@ const setup = ({
     router.get(
       '/manage-prisoner-whereabouts/select-residential-location',
       isActivitiesRolledOut,
-      selectResidentialLocationController(whereaboutsApi).index
+      selectResidentialLocationController(locationsInsidePrisonApi, systemOauthClient).index
     )
     router.post(
       '/manage-prisoner-whereabouts/select-residential-location',
       isActivitiesRolledOut,
-      selectResidentialLocationController(whereaboutsApi).post
+      selectResidentialLocationController(locationsInsidePrisonApi, systemOauthClient).post
     )
 
     router.get(

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -66,6 +66,7 @@ module.exports = defineConfig({
         stubAuthHealth: (status) => auth.stubHealth(status),
         stubPrisonApiHealth: (status) => prisonApi.stubHealth(status),
         stubWhereaboutsHealth: (status) => whereabouts.stubHealth(status),
+        stubLocationsHealth: (status) => locationsInsidePrisonApi.stubHealth(status),
         stubAllocationManagerHealth: (status) => allocationManager.stubHealth(status),
         stubKeyworkerHealth: (status) => keyworker.stubHealth(status),
         stubCaseNotesHealth: (status) => caseNotes.stubHealth(status),
@@ -78,6 +79,7 @@ module.exports = defineConfig({
             users.stubHealth(),
             prisonApi.stubHealth(),
             whereabouts.stubHealth(),
+            locationsInsidePrisonApi.stubHealth(),
             keyworker.stubHealth(),
             allocationManager.stubHealth(),
             caseNotes.stubHealth(),
@@ -468,6 +470,9 @@ module.exports = defineConfig({
         verifyMoveToCell: (body) => prisonApi.verifyMoveToCell(body),
         stubGetLocationPrefix: ({ agencyId, groupName, response }) =>
           locationsInsidePrisonApi.stubGetLocationPrefix({ agencyId, groupName, response }),
+        stubGetAgencyGroupLocations: ({ agencyId, groupName, response }) =>
+          locationsInsidePrisonApi.stubGetAgencyGroupLocations({ agencyId, groupName, response }),
+        stubGetSearchGroups: (caseload) => locationsInsidePrisonApi.stubGetSearchGroups(caseload),
         verifyMoveToCellSwap: ({ bookingId }) => prisonApi.verifyMoveToCellSwap({ bookingId }),
         stubAttendanceStats: ({ agencyId, fromDate, period, stats }) =>
           whereabouts.stubAttendanceStats(agencyId, fromDate, period, stats),
@@ -476,8 +481,6 @@ module.exports = defineConfig({
           prisonApi.stubGetEventsByLocationIds(agencyId, date, timeSlot, response),
         stubExternalTransfers: (response) => prisonApi.stubExternalTransfers(response),
         stubAssessments: (offenderNumbers) => prisonApi.stubAssessments(offenderNumbers),
-        stubGetAgencyGroupLocations: ({ agencyId, groupName, response }) =>
-          locationsInsidePrisonApi.stubGetAgencyGroupLocations({ agencyId, groupName, response }),
         stubLocationGroups: (locationGroups) => whereabouts.stubLocationGroups(locationGroups),
         stubActivityLocationsByDateAndPeriod: ({ locations, date, period, withFault }) =>
           prisonApi.stubActivityLocationsByDateAndPeriod(locations, date, period, withFault),

--- a/integration-tests/integration/activity/houseblockList.cy.js
+++ b/integration-tests/integration/activity/houseblockList.cy.js
@@ -140,6 +140,7 @@ context('Houseblock list page list page', () => {
     cy.task('stubSignIn', { username: 'ITAG_USER', caseload })
     cy.signIn()
     cy.task('stubGroups', { id: caseload })
+    cy.task('stubGetSearchGroups', { id: caseload })
     cy.task('stubActivityLocations')
     cy.task('stubGetAgencyGroupLocations', {
       agencyId: caseload,

--- a/integration-tests/integration/whereabouts/selectResidentialLocation.cy.js
+++ b/integration-tests/integration/whereabouts/selectResidentialLocation.cy.js
@@ -6,7 +6,7 @@ context('Select residential location', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubGroups', { id: 'caseload' })
+    cy.task('stubGetSearchGroups', { id: caseload })
     cy.task('stubSignIn', { username: 'ITAG_USER', caseload })
     cy.task('stubGroups', { id: 'MDI' })
     cy.signIn()

--- a/integration-tests/mockApis/locationsInsidePrisonApi.js
+++ b/integration-tests/mockApis/locationsInsidePrisonApi.js
@@ -44,4 +44,112 @@ module.exports = {
         jsonBody: response,
       },
     }),
+
+  stubGetSearchGroups: (caseload, status = 200) => {
+    const json = [
+      {
+        name: '1',
+        key: '1',
+        children: [
+          {
+            name: 'A',
+            key: 'A',
+          },
+          {
+            name: 'B',
+            key: 'B',
+          },
+          {
+            name: 'C',
+            key: 'C',
+          },
+        ],
+      },
+      {
+        name: '2',
+        key: '2',
+        children: [
+          {
+            name: 'A',
+            key: 'A',
+          },
+          {
+            name: 'B',
+            key: 'B',
+          },
+          {
+            name: 'C',
+            key: 'C',
+          },
+        ],
+      },
+      {
+        name: '3',
+        key: '3',
+        children: [
+          {
+            name: 'A',
+            key: 'A',
+          },
+          {
+            name: 'B',
+            key: 'B',
+          },
+          {
+            name: 'C',
+            key: 'C',
+          },
+        ],
+      },
+    ]
+
+    const jsonSYI = [
+      {
+        name: 'block1',
+        key: 'block1',
+        children: [
+          {
+            name: 'A',
+            key: 'A',
+          },
+          {
+            name: 'B',
+            key: 'B',
+          },
+        ],
+      },
+      {
+        name: 'block2',
+        key: 'block2',
+        children: [
+          {
+            name: 'A',
+            key: 'A',
+          },
+          {
+            name: 'B',
+            key: 'B',
+          },
+          {
+            name: 'C',
+            key: 'C',
+          },
+        ],
+      },
+    ]
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: '/locations/locations/prison/.+?/groups',
+      },
+      response: {
+        status,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: caseload.id === 'SYI' ? jsonSYI : json,
+      },
+    })
+  },
 }


### PR DESCRIPTION
see Jira [MAP-1287](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?quickFilter=3684&selectedIssue=MAP-1287)

Replacing call to whereaboutsApi.searchGroups() with locationsInsidePrisonApi.getSearchGroups() for the selectResidentialLocation.ts module.

There are other module's that still rely on whereaboutsApi.searchGroups() so it has not been removed from the codebase yet. 

[MAP-1287]: https://dsdmoj.atlassian.net/browse/MAP-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ