### PR TITLE
MAP-1287 now getting residential location groups from locationsApi

### DIFF
--- a/backend/controllers/appointments/viewAppointments.ts
+++ b/backend/controllers/appointments/viewAppointments.ts
@@ -54,7 +54,7 @@ export default ({ systemOauthClient, prisonApi, offenderSearchApi, whereaboutsAp
         locationId,
         offenderLocationPrefix,
       }),
-      whereaboutsApi.searchGroups(res.locals, agencyId),
+      locationsInsidePrisonApi.getSearchGroups(systemContext, agencyId),
     ])
 
     const videoLinkAppointmentIds = appointments

--- a/backend/tests/viewAppointmentsController.test.ts
+++ b/backend/tests/viewAppointmentsController.test.ts
@@ -15,6 +15,7 @@ describe('View appointments', () => {
 
   const locationsInsidePrisonApi = {
     getAgencyGroupLocationPrefix: jest.fn(),
+    getSearchGroups: jest.fn(),
   }
   const systemOauthClient = {
     getClientCredentialsTokens: jest.fn(),
@@ -53,11 +54,15 @@ describe('View appointments', () => {
 
     whereaboutsApi.getAppointments = jest.fn()
     whereaboutsApi.getVideoLinkAppointments = jest.fn()
-    whereaboutsApi.searchGroups = jest.fn()
 
     whereaboutsApi.getVideoLinkAppointments.mockReturnValue({ appointments: [] })
     whereaboutsApi.getAppointments.mockReturnValue([])
-    whereaboutsApi.searchGroups.mockReturnValue([
+
+    locationsInsidePrisonApi.getAgencyGroupLocationPrefix = jest.fn().mockReturnValue({
+      locationPrefix: 'MDI-1-',
+    })
+
+    locationsInsidePrisonApi.getSearchGroups.mockReturnValue([
       {
         name: 'Houseblock 1',
         key: 'H 1',
@@ -67,11 +72,6 @@ describe('View appointments', () => {
         key: 'H 2',
       },
     ])
-
-    locationsInsidePrisonApi.getAgencyGroupLocationPrefix = jest.fn()
-    locationsInsidePrisonApi.getAgencyGroupLocationPrefix = jest.fn().mockReturnValue({
-      locationPrefix: 'MDI-1-',
-    })
 
     controller = viewAppointments({
       systemOauthClient,

--- a/integration-tests/integration/appointments/viewAppointments.cy.js
+++ b/integration-tests/integration/appointments/viewAppointments.cy.js
@@ -15,7 +15,7 @@ context('A user can view list of appointments', () => {
     ])
     cy.task('stubAgencyDetails', { agencyId: 'MDI', details: {} })
     cy.task('stubUserEmail', 'ITAG_USER')
-    cy.task('stubGroups', { id: 'MDI' })
+    cy.task('stubGetSearchGroups', { id: 'MDI' })
     cy.task('stubGetWhereaboutsAppointments', [
       {
         id: 1,


### PR DESCRIPTION
moving away from whereaboutsApi to locationsInsidePrisonApi to get internal location groups.

Change applied to viewAppointments.ts so that it gets location groups from locationsInsidePrisonApi

Page affected is /view-all-appointments and component is the Residential Location select box