### PR TITLE
MAP-1287 use locationsApi to get house block groups for houseblockLocations

### DIFF
--- a/backend/api/whereaboutsApi.ts
+++ b/backend/api/whereaboutsApi.ts
@@ -59,8 +59,6 @@ export const whereaboutsApiFactory = (client) => {
       `/attendances/offender/${offenderNo}/unacceptable-absences?fromDate=${fromDate}&toDate=${toDate}&page=${page}`
     )
 
-  const searchGroups = (context, agencyId) => get(context, `/agencies/${agencyId}/locations/groups`)
-
   const getCourtLocations = (context) => get(context, '/court/courts')
 
   const addVideoLinkBooking = (context, body) => post(context, '/court/video-link-bookings', body)
@@ -122,7 +120,6 @@ export const whereaboutsApiFactory = (client) => {
     getAbsences,
     getUnacceptableAbsences,
     getUnacceptableAbsenceDetail,
-    searchGroups,
     getCourtLocations,
     addVideoLinkBooking,
     getVideoLinkAppointments,

--- a/backend/controllers/attendance/houseblockLocations.ts
+++ b/backend/controllers/attendance/houseblockLocations.ts
@@ -1,7 +1,9 @@
-export const getHouseblockLocationsFactory = ({ whereaboutsApi, logError }) => {
+export const getHouseblockLocationsFactory = (getClientCredentialsTokens, locationsInsidePrisonApi, logError) => {
   const getHouseblockLocations = async (req, res) => {
     try {
-      const response = await whereaboutsApi.searchGroups(res.locals, req.query.agencyId)
+      const systemContext = await getClientCredentialsTokens()
+
+      const response = await locationsInsidePrisonApi.getSearchGroups(systemContext, req.query.agencyId)
       return res.json(response)
     } catch (error) {
       if (error.code === 'ECONNRESET' || (error.stack && error.stack.toLowerCase().includes('timeout')))

--- a/backend/setupApiRoutes.ts
+++ b/backend/setupApiRoutes.ts
@@ -77,7 +77,7 @@ export const setup = ({
   router.use('/api/userLocations', userLocationsFactory(prisonApi).userLocations)
   router.use(
     '/api/houseblockLocations',
-    houseblockLocationsFactory({ whereaboutsApi, logError }).getHouseblockLocations
+    houseblockLocationsFactory(getClientCredentialsTokens, locationsInsidePrisonApi, logError).getHouseblockLocations
   )
   router.use('/api/activityLocations', activityLocationsFactory({ prisonApi, logError }).getActivityLocations)
   router.use('/api/houseblocklist', controller.getHouseblockList)

--- a/backend/tests/houseBlockLocations.test.ts
+++ b/backend/tests/houseBlockLocations.test.ts
@@ -2,7 +2,14 @@ import { getHouseblockLocationsFactory } from '../controllers/attendance/housebl
 import { makeResetError, makeError } from './helpers'
 
 describe('House block locations', () => {
-  const whereaboutsApi = {}
+  const getClientCredentialsTokens = jest.fn()
+
+  const systemContext = {
+    access_token: 'someToken',
+    refresh_token: undefined,
+    expires_in: 100,
+  }
+  const locationsInsidePrisonApi = {}
   const res = { locals: {} }
   const req = {
     query: {
@@ -14,8 +21,9 @@ describe('House block locations', () => {
   let logError
 
   beforeEach(() => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups = jest.fn()
+    getClientCredentialsTokens.mockResolvedValue(systemContext)
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups = jest.fn()
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'json' does not exist on type '{ locals: ... Remove this comment to see the full error message
     res.json = jest.fn()
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'status' does not exist on type '{ locals... Remove this comment to see the full error message
@@ -24,14 +32,14 @@ describe('House block locations', () => {
     res.end = jest.fn()
     logError = jest.fn()
 
-    controller = getHouseblockLocationsFactory({ whereaboutsApi, logError })
+    controller = getHouseblockLocationsFactory(getClientCredentialsTokens, locationsInsidePrisonApi, logError)
   })
 
-  it('should call searchGroups with the correct parameters', async () => {
+  it('should call getSearchGroups with the correct parameters', async () => {
     await controller.getHouseblockLocations(req, res)
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    expect(whereaboutsApi.searchGroups).toHaveBeenCalledWith({}, 'LEI')
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    expect(locationsInsidePrisonApi.getSearchGroups).toHaveBeenCalledWith(systemContext, 'LEI')
   })
 
   it('should pipe response out into json', async () => {
@@ -52,8 +60,8 @@ describe('House block locations', () => {
       },
     ]
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups.mockReturnValue(response)
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups.mockReturnValue(response)
     await controller.getHouseblockLocations(req, res)
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'json' does not exist on type '{ locals: ... Remove this comment to see the full error message
@@ -61,8 +69,8 @@ describe('House block locations', () => {
   })
 
   it('should catch and log error', async () => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups.mockRejectedValue(new Error('Test error'))
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups.mockRejectedValue(new Error('Test error'))
 
     await controller.getHouseblockLocations(req, res)
 
@@ -72,8 +80,8 @@ describe('House block locations', () => {
   })
 
   it('should not log connection reset API errors', async () => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups.mockRejectedValue(makeResetError())
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups.mockRejectedValue(makeResetError())
 
     await controller.getHouseblockLocations(req, res)
 
@@ -83,8 +91,8 @@ describe('House block locations', () => {
   })
 
   it('should respond with the correct status codes', async () => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups.mockRejectedValue(makeError('status', 403))
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups.mockRejectedValue(makeError('status', 403))
     await controller.getHouseblockLocations(req, res)
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'status' does not exist on type '{ locals... Remove this comment to see the full error message
@@ -92,8 +100,8 @@ describe('House block locations', () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'end' does not exist on type '{ locals: {... Remove this comment to see the full error message
     expect(res.end).toHaveBeenCalled()
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups.mockRejectedValue(makeError('response', { status: 404 }))
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups.mockRejectedValue(makeError('response', { status: 404 }))
     await controller.getHouseblockLocations(req, res)
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'status' does not exist on type '{ locals... Remove this comment to see the full error message
@@ -101,8 +109,8 @@ describe('House block locations', () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'end' does not exist on type '{ locals: {... Remove this comment to see the full error message
     expect(res.end).toHaveBeenCalled()
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'searchGroups' does not exist on type '{}... Remove this comment to see the full error message
-    whereaboutsApi.searchGroups.mockRejectedValue(new Error())
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getSearchGroups' does not exist on type '{}... Remove this comment to see the full error message
+    locationsInsidePrisonApi.getSearchGroups.mockRejectedValue(new Error())
     await controller.getHouseblockLocations(req, res)
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'status' does not exist on type '{ locals... Remove this comment to see the full error message

--- a/backend/tests/viewAppointmentsController.test.ts
+++ b/backend/tests/viewAppointmentsController.test.ts
@@ -10,7 +10,6 @@ describe('View appointments', () => {
   const whereaboutsApi = {
     getAppointments: jest.fn(),
     getVideoLinkAppointments: jest.fn(),
-    searchGroups: jest.fn(),
   }
 
   const locationsInsidePrisonApi = {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -108,7 +108,6 @@ module.exports = defineConfig({
 
         stubAttendanceChanges: (response) => Promise.all([whereabouts.stubAttendanceChanges(response)]),
         stubCourts: whereabouts.stubCourtLocations,
-        stubGroups: (caseload) => whereabouts.stubGroups(caseload),
         stubAddVideoLinkBooking: () => whereabouts.stubAddVideoLinkBooking(),
         getBookingRequest: () => whereabouts.getBookingRequest(),
         stubCaseNotes: caseNotes.stubCaseNotes,
@@ -481,7 +480,6 @@ module.exports = defineConfig({
           prisonApi.stubGetEventsByLocationIds(agencyId, date, timeSlot, response),
         stubExternalTransfers: (response) => prisonApi.stubExternalTransfers(response),
         stubAssessments: (offenderNumbers) => prisonApi.stubAssessments(offenderNumbers),
-        stubLocationGroups: (locationGroups) => whereabouts.stubLocationGroups(locationGroups),
         stubActivityLocationsByDateAndPeriod: ({ locations, date, period, withFault }) =>
           prisonApi.stubActivityLocationsByDateAndPeriod(locations, date, period, withFault),
         stubActivityLocationsConnectionResetFault: () => prisonApi.stubActivityLocationsConnectionResetFault(),

--- a/integration-tests/integration/activity/activityList.cy.js
+++ b/integration-tests/integration/activity/activityList.cy.js
@@ -7,7 +7,6 @@ const date = new Date().toISOString().split('T')[0]
 context('Activity list page', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubGroups', { id: caseload })
     cy.task('stubSignIn', { username: 'ITAG_USER', caseload })
     cy.signIn()
     cy.task('stubActivityLocations')

--- a/integration-tests/integration/activity/houseblockList.cy.js
+++ b/integration-tests/integration/activity/houseblockList.cy.js
@@ -139,7 +139,6 @@ context('Houseblock list page list page', () => {
     cy.task('reset')
     cy.task('stubSignIn', { username: 'ITAG_USER', caseload })
     cy.signIn()
-    cy.task('stubGroups', { id: caseload })
     cy.task('stubGetSearchGroups', { id: caseload })
     cy.task('stubActivityLocations')
     cy.task('stubGetAgencyGroupLocations', {

--- a/integration-tests/integration/activity/selectActivityLocation.cy.js
+++ b/integration-tests/integration/activity/selectActivityLocation.cy.js
@@ -5,7 +5,6 @@ context('Select activity location', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubGroups', { id: caseload })
     cy.task('stubSignIn', { username: 'ITAG_USER', caseload })
     cy.signIn()
     cy.task('stubActivityLocations')

--- a/integration-tests/integration/whereabouts/selectResidentialLocation.cy.js
+++ b/integration-tests/integration/whereabouts/selectResidentialLocation.cy.js
@@ -8,7 +8,6 @@ context('Select residential location', () => {
     cy.task('reset')
     cy.task('stubGetSearchGroups', { id: caseload })
     cy.task('stubSignIn', { username: 'ITAG_USER', caseload })
-    cy.task('stubGroups', { id: 'MDI' })
     cy.signIn()
   })
 

--- a/integration-tests/mockApis/whereabouts.js
+++ b/integration-tests/mockApis/whereabouts.js
@@ -192,113 +192,6 @@ module.exports = {
     }),
   verifyPostAttendance: () =>
     getMatchingRequests({ method: 'POST', urlPath: '/whereabouts/attendance' }).then((data) => data.body.requests),
-  stubGroups: (caseload, status = 200) => {
-    const json = [
-      {
-        name: '1',
-        key: '1',
-        children: [
-          {
-            name: 'A',
-            key: 'A',
-          },
-          {
-            name: 'B',
-            key: 'B',
-          },
-          {
-            name: 'C',
-            key: 'C',
-          },
-        ],
-      },
-      {
-        name: '2',
-        key: '2',
-        children: [
-          {
-            name: 'A',
-            key: 'A',
-          },
-          {
-            name: 'B',
-            key: 'B',
-          },
-          {
-            name: 'C',
-            key: 'C',
-          },
-        ],
-      },
-      {
-        name: '3',
-        key: '3',
-        children: [
-          {
-            name: 'A',
-            key: 'A',
-          },
-          {
-            name: 'B',
-            key: 'B',
-          },
-          {
-            name: 'C',
-            key: 'C',
-          },
-        ],
-      },
-    ]
-
-    const jsonSYI = [
-      {
-        name: 'block1',
-        key: 'block1',
-        children: [
-          {
-            name: 'A',
-            key: 'A',
-          },
-          {
-            name: 'B',
-            key: 'B',
-          },
-        ],
-      },
-      {
-        name: 'block2',
-        key: 'block2',
-        children: [
-          {
-            name: 'A',
-            key: 'A',
-          },
-          {
-            name: 'B',
-            key: 'B',
-          },
-          {
-            name: 'C',
-            key: 'C',
-          },
-        ],
-      },
-    ]
-
-    return stubFor({
-      request: {
-        method: 'GET',
-        url: `/whereabouts/agencies/${caseload.id}/locations/groups`,
-      },
-      response: {
-        status,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: caseload.id === 'SYI' ? jsonSYI : json,
-      },
-    })
-  },
 
   stubCellsWithCapacityByGroupName: ({ agencyId, groupName, response }) =>
     stubFor({
@@ -312,20 +205,6 @@ module.exports = {
           'Content-Type': 'application/json;charset=UTF-8',
         },
         jsonBody: response,
-      },
-    }),
-  stubLocationGroups: (locationGroups) =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPathPattern: '/whereabouts/agencies/.+?/locations/groups',
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: locationGroups || [],
       },
     }),
   stubLocationConfig: ({ agencyId, response }) =>


### PR DESCRIPTION
Call to locationsApi replaces call previously made to whereaboutsApi
Removed any remaining references to whereaboutsApi.searchGroups()

Affects /manage-prisoner-whereabouts/housing-block-results