### PR TITLE
MICN-113 use filtered case note type and sub type endpoint

### DIFF
--- a/backend/api/caseNotesApi.test.ts
+++ b/backend/api/caseNotesApi.test.ts
@@ -16,7 +16,9 @@ describe('caseNoteApi tests', () => {
 
   describe('GET requests', () => {
     it('Extracts GET response data', async () => {
-      mock.get('/case-notes/types').reply(200, { test: 'test' })
+      mock
+        .get('/case-notes/types?selectableBy=ALL&includeInactive=true&includeRestricted=true')
+        .reply(200, { test: 'test' })
       const data = await caseNoteAPi.getCaseNoteTypes({})
       expect(data).toEqual({ test: 'test' })
     })

--- a/backend/api/caseNotesApi.ts
+++ b/backend/api/caseNotesApi.ts
@@ -57,8 +57,15 @@ export const caseNotesApiFactory = (client) => {
   const amendCaseNote = (context, offenderNo, caseNoteId, data?) =>
     client.put(context, `/case-notes/${offenderNo}/${caseNoteId}`, data).then(processResponse(context))
 
-  const getCaseNoteTypes = (context) => get(context, '/case-notes/types')
-  const myCaseNoteTypes = (context) => get(context, '/case-notes/types-for-user')
+  const getCaseNoteTypes = (context) =>
+    get(context, '/case-notes/types?selectableBy=ALL&includeInactive=true&includeRestricted=true')
+
+  const myCaseNoteTypes = (context) => {
+    if (context?.userRoles?.find((role) => ['POM', 'ADD_SENSITIVE_CASE_NOTES'].includes(role.roleCode))) {
+      return get(context, '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=true')
+    }
+    return get(context, '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=false')
+  }
 
   const getCaseNote = (context, offenderNo, caseNoteId) => get(context, `/case-notes/${offenderNo}/${caseNoteId}`)
 

--- a/backend/api/caseNotesApi.ts
+++ b/backend/api/caseNotesApi.ts
@@ -61,10 +61,21 @@ export const caseNotesApiFactory = (client) => {
     get(context, '/case-notes/types?selectableBy=ALL&includeInactive=true&includeRestricted=true')
 
   const myCaseNoteTypes = (context) => {
-    if (context?.userRoles?.find((role) => ['POM', 'ADD_SENSITIVE_CASE_NOTES'].includes(role.roleCode))) {
-      return get(context, '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=true')
+    const contextWithClientToken = {
+      ...context,
+      access_token: context.clientToken,
     }
-    return get(context, '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=false')
+
+    if (context?.userRoles?.find((role) => ['POM', 'ADD_SENSITIVE_CASE_NOTES'].includes(role.roleCode))) {
+      return get(
+        contextWithClientToken,
+        '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=true'
+      )
+    }
+    return get(
+      contextWithClientToken,
+      '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=false'
+    )
   }
 
   const getCaseNote = (context, offenderNo, caseNoteId) => get(context, `/case-notes/${offenderNo}/${caseNoteId}`)

--- a/backend/api/caseNotesApi.ts
+++ b/backend/api/caseNotesApi.ts
@@ -61,21 +61,10 @@ export const caseNotesApiFactory = (client) => {
     get(context, '/case-notes/types?selectableBy=ALL&includeInactive=true&includeRestricted=true')
 
   const myCaseNoteTypes = (context) => {
-    const contextWithClientToken = {
-      ...context,
-      access_token: context.clientToken,
-    }
-
     if (context?.userRoles?.find((role) => ['POM', 'ADD_SENSITIVE_CASE_NOTES'].includes(role.roleCode))) {
-      return get(
-        contextWithClientToken,
-        '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=true'
-      )
+      return get(context, '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=true')
     }
-    return get(
-      contextWithClientToken,
-      '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=false'
-    )
+    return get(context, '/case-notes/types?selectableBy=DPS_USER&includeInactive=false&includeRestricted=false')
   }
 
   const getCaseNote = (context, offenderNo, caseNoteId) => get(context, `/case-notes/${offenderNo}/${caseNoteId}`)

--- a/backend/controllers/caseNote.ts
+++ b/backend/controllers/caseNote.ts
@@ -18,7 +18,12 @@ const getContextWithRoles = async (offenderNo, res, req, oauthApi, systemOauthCl
     restrictedPatientApi,
   })
 
-  return context
+  const username = req.session?.userDetails?.username || 'SYSTEM'
+  const { access_token: clientToken } = await systemOauthClient.getClientCredentialsTokens(username)
+  return {
+    ...context,
+    clientToken,
+  }
 }
 
 export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauthClient, restrictedPatientApi }) => {

--- a/backend/controllers/prisonerProfile/prisonerCaseNotes.ts
+++ b/backend/controllers/prisonerProfile/prisonerCaseNotes.ts
@@ -58,7 +58,11 @@ export default ({
       endDate: toDate,
     })
 
-    const caseNoteTypes = await caseNotesApi.getCaseNoteTypes(context)
+    const { access_token: clientToken } = await systemOauthClient.getClientCredentialsTokens(username)
+    const caseNoteTypes = await caseNotesApi.getCaseNoteTypes({
+      ...context,
+      access_token: clientToken,
+    })
 
     const types = caseNoteTypes.map((caseNoteType) => ({
       value: caseNoteType.code,

--- a/backend/tests/caseNote.test.ts
+++ b/backend/tests/caseNote.test.ts
@@ -8,7 +8,7 @@ Reflect.deleteProperty(process.env, 'APPINSIGHTS_INSTRUMENTATIONKEY')
 const prisonApi = { getDetails: {} }
 const caseNotesApi = { addCaseNote: {}, myCaseNoteTypes: {} }
 const restrictedPatientApi = {}
-const systemOauthClient = {}
+const systemOauthClient = { getClientCredentialsTokens: () => ({ access_token: 'CLIENT_TOKEN' }) }
 const oauthApi = {}
 
 const { index, post, areYouSure, confirm, recordIncentiveLevelInterruption } = caseNoteCtrl.caseNoteFactory({
@@ -485,7 +485,7 @@ describe('case note management', () => {
 
         await post(req, res)
 
-        expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
+        expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
           offenderNo,
           type: 'OBSERVE',
           subType: 'OBS1',
@@ -510,7 +510,7 @@ describe('case note management', () => {
         }
 
         const expectCaseNoteAdded = () =>
-          expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
+          expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
             offenderNo,
             type: 'REPORTS',
             subType: 'REP_IEP',
@@ -581,7 +581,7 @@ describe('case note management', () => {
 
       await confirm(req, res)
 
-      expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
+      expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
         text: 'hello',
         date: '20/01/2020',
         hours: '23',
@@ -609,7 +609,7 @@ describe('case note management', () => {
 
       await confirm(req, res)
 
-      expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
+      expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
         text: 'hello',
         date: '20/01/2020',
         hours: '23',

--- a/backend/tests/caseNote.test.ts
+++ b/backend/tests/caseNote.test.ts
@@ -485,7 +485,7 @@ describe('case note management', () => {
 
         await post(req, res)
 
-        expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
+        expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
           offenderNo,
           type: 'OBSERVE',
           subType: 'OBS1',
@@ -510,7 +510,7 @@ describe('case note management', () => {
         }
 
         const expectCaseNoteAdded = () =>
-          expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
+          expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
             offenderNo,
             type: 'REPORTS',
             subType: 'REP_IEP',
@@ -581,7 +581,7 @@ describe('case note management', () => {
 
       await confirm(req, res)
 
-      expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
+      expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
         text: 'hello',
         date: '20/01/2020',
         hours: '23',
@@ -609,7 +609,7 @@ describe('case note management', () => {
 
       await confirm(req, res)
 
-      expect(caseNotesApi.addCaseNote).toBeCalledWith({ ...res.locals, clientToken: 'CLIENT_TOKEN' }, offenderNo, {
+      expect(caseNotesApi.addCaseNote).toBeCalledWith(res.locals, offenderNo, {
         text: 'hello',
         date: '20/01/2020',
         hours: '23',

--- a/backend/tests/caseNotesController.test.ts
+++ b/backend/tests/caseNotesController.test.ts
@@ -36,7 +36,7 @@ describe('Case notes controller', () => {
   const paginationService = {}
   const nunjucks = {}
   const oauthApi = {}
-  const systemOauthClient = {}
+  const systemOauthClient = { getClientCredentialsTokens: () => ({ access_token: 'CLIENT_TOKEN' }) }
   const restrictedPatientApi = {}
 
   let controller

--- a/integration-tests/mockApis/caseNotes.js
+++ b/integration-tests/mockApis/caseNotes.js
@@ -104,12 +104,12 @@ module.exports = {
     }),
   stubCaseNoteTypes: (types) =>
     getFor({
-      urlPattern: '/casenotes/case-notes/types',
+      urlPattern: '/casenotes/case-notes/types.+?',
       body: types || caseNoteTypes,
     }),
   stubCaseNoteTypesForUser: (types) =>
     getFor({
-      urlPattern: '/casenotes/case-notes/types-for-user',
+      urlPattern: '/casenotes/case-notes/types.+?',
       body: types || caseNoteTypes,
     }),
   stubGetCaseNote: (response) =>


### PR DESCRIPTION
this PR corresponds to the same changes in prisoner profile: https://github.com/ministryofjustice/hmpps-prisoner-profile/pull/706

- replace GET /case-notes/types-for-user call with GET /case-notes/types using the correct filters. GET /case-notes/type-for-user endpoint will be deprecated.
- set query params of what kind of CaseNoteSubTypes to be included for GET /case-notes/types calls (namely, selectable by DPS_USER or by ALL; include INACTIVE and/or RESTRICTED subtypes), based on the user's roles.