### PR TITLE
MICN-164 Update case note subtype to use `active` instead of `activeFlag`

### DIFF
--- a/backend/controllers/caseNote.ts
+++ b/backend/controllers/caseNote.ts
@@ -33,9 +33,7 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
   }
 
   const getCaseNoteTypes = async (context, type) => {
-    const caseNoteTypes = (await caseNotesApi.myCaseNoteTypes(context)).filter(
-      (caseNoteType) => caseNoteType.activeFlag === 'Y'
-    )
+    const caseNoteTypes = await caseNotesApi.myCaseNoteTypes(context)
 
     const types = caseNoteTypes.map((caseNoteType) => ({
       value: caseNoteType.code,
@@ -46,7 +44,7 @@ export const caseNoteFactory = ({ prisonApi, caseNotesApi, oauthApi, systemOauth
       .filter((caseNoteType) => caseNoteType.code === type)
       .map((caseNoteType) =>
         caseNoteType.subCodes
-          .filter((sub) => sub.activeFlag === 'Y')
+          .filter((sub) => sub.active)
           .map((subCode) => ({
             type: caseNoteType.code,
             value: subCode.code,

--- a/backend/tests/caseNote.test.ts
+++ b/backend/tests/caseNote.test.ts
@@ -44,27 +44,25 @@ describe('case note management', () => {
     {
       code: 'OBSERVE',
       description: 'Observations',
-      activeFlag: 'Y',
       source: 'OCNS',
       subCodes: [
         {
           type: 'OBSERVE',
           code: 'OBS1',
           description: 'Observation 1',
-          activeFlag: 'Y',
+          active: true,
         },
       ],
     },
     {
       code: 'ACHIEVEMENTS',
       description: 'Achievements',
-      activeFlag: 'Y',
       subCodes: [
         {
           type: 'ACHIEVEMENTS',
           code: 'ACH1',
           description: 'Achievement 1',
-          activeFlag: 'Y',
+          active: true,
         },
       ],
     },

--- a/integration-tests/mockApis/caseNotes.js
+++ b/integration-tests/mockApis/caseNotes.js
@@ -4,47 +4,43 @@ const caseNoteTypes = [
   {
     code: 'OBSERVE',
     description: 'Observations',
-    activeFlag: 'Y',
     source: 'OCNS',
     subCodes: [
       {
         code: 'test',
         description: 'Test',
-        activeFlag: 'Y',
+        active: true,
       },
     ],
   },
   {
     code: 'OMIC',
     description: 'OMiC',
-    activeFlag: 'Y',
     source: 'OCNS',
     subCodes: [
       {
         code: 'OPEN_COMM',
         description: 'Open Case Note',
-        activeFlag: 'Y',
+        active: true,
       },
       {
         code: 'COMM',
         description: 'OMiC Communication',
-        activeFlag: 'Y',
+        active: true,
       },
     ],
   },
   {
     code: 'POS',
     description: 'Positive Behaviour',
-    activeFlag: 'Y',
-    subCodes: [{ code: 'IEP_ENC', description: 'Incentive Encouragement', activeFlag: 'Y' }],
+    subCodes: [{ code: 'IEP_ENC', description: 'Incentive Encouragement', active: true }],
   },
   {
     code: 'NEG',
     description: 'Negative Behaviour',
-    activeFlag: 'Y',
     subCodes: [
-      { code: 'BEHAVEWARN', description: 'Behaviour Warning', activeFlag: 'Y' },
-      { code: 'IEP_WARN', description: 'Incentive Warning', activeFlag: 'Y' },
+      { code: 'BEHAVEWARN', description: 'Behaviour Warning', active: true },
+      { code: 'IEP_WARN', description: 'Incentive Warning', active: true },
     ],
   },
 ]


### PR DESCRIPTION
MICN-164

`activeFlag` is now only used for Case Note Child type but not on Parent type.
and it is refactored into a boolean (`active`) in offender-case-notes service.

This PR updates case note api service to follow the updated API specs of offender-case-notes