### PR TITLE
BAVL-382 moving feature toggle to K8s so can switch toggle without having to redeploy the service.

### DIFF
--- a/helm_deploy/digital-prison-services/values.yaml
+++ b/helm_deploy/digital-prison-services/values.yaml
@@ -67,12 +67,12 @@ generic-service:
       BRONZEFIELD_OMU_EMAIL: "BRONZEFIELD_OMU_EMAIL"
       PENTONVILLE_OMU_EMAIL: "PENTONVILLE_OMU_EMAIL"
       EXETER_OMU_EMAIL: "EXETER_OMU_EMAIL"
+    feature-toggles:
+      BOOK_A_VIDEO_LINK_API_ENABLED: "BOOK_A_VIDEO_LINK_API_ENABLED"
 
     dps-redis:
       REDIS_HOST: "REDIS_HOST"
       REDIS_PASSWORD: "REDIS_PASSWORD"
-
-
 
 generic-prometheus-alerts:
   targetApplication: digital-prison-services

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -46,7 +46,6 @@ generic-service:
    CURIOUS_URL: https://testservices.sequation.net/sequation-virtual-campus2-api/
    SYSTEM_PHASE: DEV
    BVL_URL: https://book-video-link-dev.prison.service.justice.gov.uk
-   BOOK_A_VIDEO_LINK_API_ENABLED: "true"
    BOOK_A_VIDEO_LINK_API_URL: https://book-a-video-link-api-dev.prison.service.justice.gov.uk
    MOIC_URL: https://dev.moic.service.justice.gov.uk
    OMIC_URL: https://dev.manage-key-workers.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -39,7 +39,6 @@ generic-service:
     SUPPORT_URL: https://support-preprod.hmpps.service.justice.gov.uk/
     SYSTEM_PHASE: PRE-PRODUCTION
     BVL_URL: https://book-video-link-preprod.prison.service.justice.gov.uk
-    BOOK_A_VIDEO_LINK_API_ENABLED: "true"
     BOOK_A_VIDEO_LINK_API_URL: https://book-a-video-link-api-preprod.prison.service.justice.gov.uk
     MOIC_URL: https://preprod.moic.service.justice.gov.uk
     OMIC_URL: https://preprod.manage-key-workers.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -37,7 +37,6 @@ generic-service:
     OFFENDER_SEARCH_API_URL: https://prisoner-search.prison.service.justice.gov.uk
     SUPPORT_URL: https://support.hmpps.service.justice.gov.uk/
     BVL_URL: https://book-video-link.prison.service.justice.gov.uk
-    BOOK_A_VIDEO_LINK_API_ENABLED: "false"
     BOOK_A_VIDEO_LINK_API_URL: https://book-a-video-link-api.prison.service.justice.gov.uk
     MOIC_URL: https://moic.service.justice.gov.uk
     OMIC_URL: https://manage-key-workers.service.justice.gov.uk


### PR DESCRIPTION
The BVLS team are preparing for rollout, and we have various feature toggles to flip on, on the day of rollout. To reduce dependency and disruption on other teams, we want to convert the toggles to namespace secrets, so that we can flip their value without the need for a new helm deployment.

The secret has been applied to the relevant Digital Prison Service namespaces:
- dev = true
- preprod = true
- prod = false.