### PR TITLE
SAA-2029: Whereabouts-UI-add-no-longer-in-service-page

### DIFF
--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -69,7 +69,9 @@ const isActivitiesRolledOut = (req, res, next) => {
     activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
     appointments.enabled_prisons.split(',').includes(activeCaseLoadId)
   ) {
-    res.redirect('/')
+    res.render('whereaboutsServiceDeactivated.njk', {
+      activeCaseLoadId,
+    })
   } else {
     next()
   }
@@ -348,6 +350,20 @@ const setup = ({
     '/offenders/:offenderNo/retention-reasons',
     retentionReasonsRouter({ prisonApi, dataComplianceApi, logError })
   )
+
+  router.use('/manage-prisoner-whereabouts/activity-results*', (req, res, next) => {
+    const { activeCaseLoadId } = req.session.userDetails
+    if (
+      activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
+      appointments.enabled_prisons.split(',').includes(activeCaseLoadId)
+    )
+      res.render('whereaboutsServiceDeactivated.njk', {
+        activeCaseLoadId,
+      })
+    else {
+      next()
+    }
+  })
 
   router.use('/change-someones-cell', (req, res) => res.redirect('/change-someones-cell-has-moved'))
 

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -354,13 +354,13 @@ const setup = ({
   router.use('/manage-prisoner-whereabouts/activity-results*', (req, res, next) => {
     const { activeCaseLoadId } = req.session.userDetails
     if (
-      activities.enabled_prisons.split(',').includes(activeCaseLoadId) &&
+      activities.enabled_prisons.split(',').includes(activeCaseLoadId) ||
       appointments.enabled_prisons.split(',').includes(activeCaseLoadId)
-    )
+    ) {
       res.render('whereaboutsServiceDeactivated.njk', {
         activeCaseLoadId,
       })
-    else {
+    } else {
       next()
     }
   })

--- a/views/whereaboutsServiceDeactivated.njk
+++ b/views/whereaboutsServiceDeactivated.njk
@@ -1,0 +1,42 @@
+{% extends "./partials/layout.njk" %}
+{% from "./components/card/card.njk" import card %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% set feedbackBannerBackground = '#f0f4f5 '%}
+
+{% set title =  "Service no longer available" %}
+
+{% block main %}
+  <div class="govuk-width-container">
+    {{ govukBackLink({
+      text: "Digital Prison Services",
+      href: "/"
+    }) }}
+  </div>
+
+  <div class="govuk-width-container">
+
+    {% set mainClasses = "govuk-main-wrapper--l" %}
+    <div class="govuk-grid-row govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">You can no longer use the prisoner whereabouts service in {{ activeCaseLoadId }} (HMP) </h1>
+        <p class="govuk-body">
+          It's been replaced by the new activities and appointments management service.
+
+          Select 'Activties, unlock and attendance' or 'appointments scheduling and attendance' from the DPS homepage.
+        </p>
+      </div>
+    </div>
+
+    <p class="govuk-body">
+        {{ govukButton({
+            text: "Go to DPS homepage",
+            href: '/'
+        }) }}
+    </p>
+  </div>
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/static/js/card.js"></script>
+{% endblock %}


### PR DESCRIPTION
UI Redirect to prevent user actioning attendance in whereabouts service when activities and appointments service is live 

![Screenshot 2024-11-18 at 11 32 28](https://github.com/user-attachments/assets/1f790228-aff4-444a-82d7-71d4bfd79725)
