### PR TITLE
Map old Prison API locations to new Locations for Video Link Bookings

### DIFF
--- a/backend/api/bookAVideoLinkApi.ts
+++ b/backend/api/bookAVideoLinkApi.ts
@@ -7,10 +7,10 @@ export const bookAVideoLinkApiFactory = (client) => {
   const post = (systemContext, url, data) => client.post(systemContext, url, data).then(processResponse())
   const sendDelete = (systemContext, url) => client.sendDelete(systemContext, url).then(processResponse())
 
-  const matchAppointmentToVideoLinkBooking = (systemContext, { offenderNo, startTime, endTime }, { locationPrefix }) =>
+  const matchAppointmentToVideoLinkBooking = (systemContext, { offenderNo, startTime, endTime }, { key }) =>
     post(systemContext, `/video-link-booking/search`, {
       prisonerNumber: offenderNo,
-      locationKey: locationPrefix,
+      locationKey: key,
       date: moment(startTime).format('YYYY-MM-DD'),
       startTime: moment(startTime).format('HH:mm'),
       endTime: moment(endTime).format('HH:mm'),

--- a/backend/api/locationsInsidePrisonApi.ts
+++ b/backend/api/locationsInsidePrisonApi.ts
@@ -5,6 +5,7 @@ export interface LocationPrefix {
 }
 
 export interface Location {
+  id: string
   key: string
 }
 
@@ -37,6 +38,12 @@ export const locationsInsidePrisonApiFactory = (client: OauthApiClient) => {
   const getAgencyGroupLocations = (systemContext, prisonId, groupName): Promise<Location[]> =>
     getWith404AsNull(systemContext, `/locations/groups/${prisonId}/${groupName}`)
 
+  const getLocationById = (systemContext, locationId): Promise<Location> =>
+    getWith404AsNull(systemContext, `/locations/${locationId}`)
+
+  const getLocationByKey = (systemContext, locationKey): Promise<Location> =>
+    getWith404AsNull(systemContext, `/locations/key/${locationKey}`)
+
   const getSearchGroups = (context, prisonId): Promise<LocationGroup[]> => {
     return getWith404AsNull(context, `/locations/prison/${prisonId}/groups`)
   }
@@ -45,6 +52,8 @@ export const locationsInsidePrisonApiFactory = (client: OauthApiClient) => {
     getAgencyGroupLocationPrefix,
     getAgencyGroupLocations,
     getSearchGroups,
+    getLocationById,
+    getLocationByKey,
   }
 }
 

--- a/backend/api/nomisMappingClient.ts
+++ b/backend/api/nomisMappingClient.ts
@@ -1,0 +1,27 @@
+import type { OauthApiClient } from './oauthEnabledClient'
+
+type NomisDpsLocationMapping = {
+  dpsLocationId: string
+  nomisLocationId: number
+}
+
+export const nomisMappingClientFactory = (client: OauthApiClient) => {
+  const processResponse = () => (response) => response.body
+
+  const get = (systemContext, url) => client.get(systemContext, url).then(processResponse())
+
+  const getNomisLocationMappingByDpsLocationId = (systemContext, dpsLocationId): Promise<NomisDpsLocationMapping> =>
+    get(systemContext, `/api/locations/dps/${dpsLocationId}`)
+
+  const getNomisLocationMappingByNomisLocationId = (systemContext, nomisLocationId): Promise<NomisDpsLocationMapping> =>
+    get(systemContext, `/api/locations/nomis/${nomisLocationId}`)
+
+  return {
+    getNomisLocationMappingByDpsLocationId,
+    getNomisLocationMappingByNomisLocationId,
+  }
+}
+
+export default {
+  nomisMappingClientFactory,
+}

--- a/backend/apis.ts
+++ b/backend/apis.ts
@@ -22,6 +22,7 @@ import { nonAssociationsApiFactory } from './api/nonAssociationsApi'
 import { hmppsManageUsersApiFactory } from './api/hmppsManageUsersApi'
 import { feComponentsApiFactory } from './api/feComponents'
 import { bookAVideoLinkApiFactory } from './api/bookAVideoLinkApi'
+import { nomisMappingClientFactory } from './api/nomisMappingClient'
 
 export const prisonApi = prisonApiFactory(
   clientFactory({
@@ -48,6 +49,13 @@ export const locationsInsidePrisonApi = locationsInsidePrisonApiFactory(
   clientFactory({
     baseUrl: config.apis.locationsInsidePrisonApi.url,
     timeout: config.apis.locationsInsidePrisonApi.timeoutSeconds * 1000,
+  })
+)
+
+export const nomisMapping = nomisMappingClientFactory(
+  clientFactory({
+    baseUrl: config.apis.nomisMapping.url,
+    timeout: config.apis.nomisMapping.timeoutSeconds * 1000,
   })
 )
 
@@ -188,4 +196,5 @@ export default {
   nonAssociationsApi,
   restrictedPatientApi,
   feComponentsApi,
+  nomisMapping,
 }

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -106,6 +106,10 @@ export const apis = {
     url: process.env.API_LOCATIONS_INSIDE_PRISON_ENDPOINT_URL || 'http://localhost:8082/',
     timeoutSeconds: toNumber(process.env.API_LOCATIONS_INSIDE_PRISON_ENDPOINT_TIMEOUT_SECONDS) || 30,
   },
+  nomisMapping: {
+    url: process.env.API_NOMIS_MAPPING_ENDPOINT_URL || 'http://localhost:8090/',
+    timeoutSeconds: toNumber(process.env.API_NOMIS_MAPPING_ENDPOINT_TIMEOUT_SECONDS) || 30,
+  },
   deliusIntegration: {
     url: process.env.API_DELIUS_ENDPOINT_URL || 'http://localhost:8083/delius',
     timeoutSeconds: toNumber(process.env.API_DELIUS_ENDPOINT_TIMEOUT_SECONDS) || 30,

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -123,6 +123,7 @@ app.use(
     incentivesApi: apis.incentivesApi,
     nonAssociationsApi: apis.nonAssociationsApi,
     restrictedPatientApi: apis.restrictedPatientApi,
+    nomisMapping: apis.nomisMapping,
     whereaboutsMaintenanceMode: config.app.whereaboutsMaintenanceMode,
     getClientCredentialsTokens,
   })

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -138,11 +138,13 @@ const setup = ({
   restrictedPatientApi,
   whereaboutsMaintenanceMode,
   getClientCredentialsTokens,
+  nomisMapping,
 }) => {
   const videoLinkBookingService = videoLinkBookingServiceFactory({
     whereaboutsApi,
     bookAVideoLinkApi,
-    prisonApi,
+    locationsInsidePrisonApi,
+    nomisMapping,
   })
 
   router.use(async (req, res, next) => {
@@ -444,6 +446,8 @@ const setup = ({
         appointmentDetailsService: appointmentDetailsServiceFactory({
           prisonApi,
           videoLinkBookingService,
+          locationsInsidePrisonApi,
+          nomisMapping,
           getClientCredentialsTokens,
         }),
         videoLinkBookingService,
@@ -458,6 +462,8 @@ const setup = ({
         appointmentDetailsService: appointmentDetailsServiceFactory({
           prisonApi,
           videoLinkBookingService,
+          locationsInsidePrisonApi,
+          nomisMapping,
           getClientCredentialsTokens,
         }),
         videoLinkBookingService,
@@ -489,6 +495,8 @@ const setup = ({
         appointmentDetailsService: appointmentDetailsServiceFactory({
           prisonApi,
           videoLinkBookingService,
+          locationsInsidePrisonApi,
+          nomisMapping,
           getClientCredentialsTokens,
         }),
       })

--- a/backend/services/healthCheck.ts
+++ b/backend/services/healthCheck.ts
@@ -46,7 +46,9 @@ export default function healthcheckFactory(
   offenderSearchUrl,
   complexityUrl,
   incentivesApiUrl,
-  bookAVideoLinkUrl
+  bookAVideoLinkUrl,
+  locationsInsidePrisonApiUrl,
+  nomisMappingUrl
 ) {
   const checks = [
     service('auth', authUrl),
@@ -59,6 +61,8 @@ export default function healthcheckFactory(
     service('offenderSearch', offenderSearchUrl),
     service('complexity', complexityUrl),
     service('incentivesApi', incentivesApiUrl),
+    service('locationsInsidePrisonApi', locationsInsidePrisonApiUrl),
+    service('nomisMapping', nomisMappingUrl),
   ]
 
   if (config.apis.bookAVideoLinkApi.enabled) {

--- a/backend/services/videoLinkBookingService.ts
+++ b/backend/services/videoLinkBookingService.ts
@@ -2,13 +2,15 @@ import moment from 'moment'
 import { getWith404AsNull } from '../utils'
 import config from '../config'
 
-export default ({ whereaboutsApi, bookAVideoLinkApi, prisonApi }) => {
+export default ({ whereaboutsApi, bookAVideoLinkApi, locationsInsidePrisonApi, nomisMapping }) => {
   const getVideoLinkBookingFromAppointmentId = async (
     context,
     appointmentId
   ): Promise<{ videoLinkBookingId: number }> => {
     const appointmentDetails = await whereaboutsApi.getAppointment(context, appointmentId)
-    const location = await prisonApi.getLocation(context, appointmentDetails.appointment.locationId)
+    const location = await nomisMapping
+      .getNomisLocationMappingByNomisLocationId(context, appointmentDetails.appointment.locationId)
+      .then((mapping) => locationsInsidePrisonApi.getLocationById(context, mapping.dpsLocationId))
 
     return appointmentDetails.appointment.appointmentTypeCode === 'VLB' && config.apis.bookAVideoLinkApi.enabled
       ? getWith404AsNull(

--- a/backend/setupHealthChecks.ts
+++ b/backend/setupHealthChecks.ts
@@ -18,7 +18,9 @@ const health = healthFactory(
   joinUrlPath(config.apis.offenderSearch.url, '/health/ping'),
   joinUrlPath(config.apis.complexity.url, '/ping'),
   joinUrlPath(config.apis.incentivesApi.url, '/health/ping'),
-  joinUrlPath(config.apis.bookAVideoLinkApi.url, '/health/ping')
+  joinUrlPath(config.apis.bookAVideoLinkApi.url, '/health/ping'),
+  joinUrlPath(config.apis.locationsInsidePrisonApi.url, '/health/ping'),
+  joinUrlPath(config.apis.nomisMapping.url, '/health/ping')
 )
 
 export default () => {

--- a/backend/tests/appointmentDetails.test.ts
+++ b/backend/tests/appointmentDetails.test.ts
@@ -22,6 +22,8 @@ describe('appointment details', () => {
   const prisonApi = {}
   const whereaboutsApi = {}
   const videoLinkBookingService = {}
+  const locationsInsidePrisonApi = {}
+  const nomisMapping = {}
   const getClientCredentialsTokens = {}
 
   let req
@@ -69,6 +71,8 @@ describe('appointment details', () => {
     appointmentDetailsService = appointmentDetailsServiceFactory({
       prisonApi,
       videoLinkBookingService,
+      locationsInsidePrisonApi,
+      nomisMapping,
       getClientCredentialsTokens,
     })
 

--- a/backend/tests/appointmentDetailsService.test.ts
+++ b/backend/tests/appointmentDetailsService.test.ts
@@ -20,8 +20,8 @@ describe('appointment details', () => {
 
   const prisonApi = {}
   const videoLinkBookingService = { getVideoLinkBookingFromAppointmentId: jest.fn(), bookingIsAmendable: jest.fn() }
-  const locationsInsidePrisonApi = {}
-  const nomisMapping = {}
+  const locationsInsidePrisonApi = { getLocationByKey: jest.fn() }
+  const nomisMapping = { getNomisLocationMappingByDpsLocationId: jest.fn() }
   const getClientCredentialsTokens = jest.fn()
 
   let res
@@ -318,6 +318,9 @@ describe('appointment details', () => {
     })
 
     it('should render with court location and correct vlb locations and types', async () => {
+      locationsInsidePrisonApi.getLocationByKey.mockResolvedValue({ id: 'abc-123' })
+      nomisMapping.getNomisLocationMappingByDpsLocationId.mockResolvedValue({ nomisLocationId: 2 })
+
       const appointmentDetails = await service.getAppointmentViewModel(res, videoLinkBookingAppointment, 'MDI')
 
       expect(appointmentDetails).toMatchObject({

--- a/backend/tests/appointmentDetailsService.test.ts
+++ b/backend/tests/appointmentDetailsService.test.ts
@@ -20,6 +20,8 @@ describe('appointment details', () => {
 
   const prisonApi = {}
   const videoLinkBookingService = { getVideoLinkBookingFromAppointmentId: jest.fn(), bookingIsAmendable: jest.fn() }
+  const locationsInsidePrisonApi = {}
+  const nomisMapping = {}
   const getClientCredentialsTokens = jest.fn()
 
   let res
@@ -50,7 +52,13 @@ describe('appointment details', () => {
       .fn()
       .mockResolvedValue({ username: 'TEST_USER', firstName: 'TEST', lastName: 'USER' })
 
-    service = appointmentDetailsServiceFactory({ prisonApi, videoLinkBookingService, getClientCredentialsTokens })
+    service = appointmentDetailsServiceFactory({
+      prisonApi,
+      videoLinkBookingService,
+      locationsInsidePrisonApi,
+      nomisMapping,
+      getClientCredentialsTokens,
+    })
   })
 
   describe('an appointment view model request', () => {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,7 @@ const dataComplianceApi = require('./integration-tests/mockApis/dataCompliance')
 const prisonerProfile = require('./integration-tests/mockApis/prisonerProfile')
 const whereabouts = require('./integration-tests/mockApis/whereabouts')
 const locationsInsidePrisonApi = require('./integration-tests/mockApis/locationsInsidePrisonApi')
+const nomisMapping = require('./integration-tests/mockApis/nomisMapping')
 const tokenverification = require('./integration-tests/mockApis/tokenverification')
 const keyworker = require('./integration-tests/mockApis/keyworker')
 const caseNotes = require('./integration-tests/mockApis/caseNotes')
@@ -87,6 +88,7 @@ module.exports = defineConfig({
             delius.stubHealth(),
             offenderSearch.stubHealth(),
             complexity.stubHealth(),
+            nomisMapping.stubHealth(),
           ]),
         getSignInUrl: auth.getSignInUrl,
         stubSignIn: ({ username = 'ITAG_USER', caseload = 'MDI', roles = [], caseloads }) =>

--- a/cypress.env
+++ b/cypress.env
@@ -6,6 +6,7 @@ CASENOTES_API_URL=http://localhost:9191/casenotes/
 ALLOCATION_MANAGER_ENDPOINT_URL=http://localhost:9191/allocation/
 API_WHEREABOUTS_ENDPOINT_URL=http://localhost:9191/whereabouts/
 API_LOCATIONS_INSIDE_PRISON_ENDPOINT_URL=http://localhost:9191/locations/
+API_NOMIS_MAPPING_ENDPOINT_URL=http://localhost:9191/nomis-mapping/
 API_DELIUS_ENDPOINT_URL=http://localhost:9191/delius/
 KEYWORKER_API_URL=http://localhost:9191/keyworker/
 RESTRICTED_PATIENT_API_URL=http://localhost:9191/restricted-patient/

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,7 @@ generic-service:
    HMPPS_MANAGE_USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
    API_WHEREABOUTS_ENDPOINT_URL: https://whereabouts-api-dev.service.justice.gov.uk/
    API_LOCATIONS_INSIDE_PRISON_ENDPOINT_URL: https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk
+   API_NOMIS_MAPPING_ENDPOINT_URL: https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk
    LICENCES_URL: https://licences-dev.prison.service.justice.gov.uk/
    HMPPS_COOKIE_NAME: hmpps-session-dev
    API_DELIUS_ENDPOINT_URL: https://dps-and-delius-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,7 @@ generic-service:
     HMPPS_MANAGE_USERS_API_URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
     API_WHEREABOUTS_ENDPOINT_URL: https://whereabouts-api-preprod.service.justice.gov.uk/
     API_LOCATIONS_INSIDE_PRISON_ENDPOINT_URL: https://locations-inside-prison-api-preprod.hmpps.service.justice.gov.uk
+    API_NOMIS_MAPPING_ENDPOINT_URL: https://nomis-sync-prisoner-mapping-preprod.hmpps.service.justice.gov.uk
     LICENCES_URL: https://licences-preprod.prison.service.justice.gov.uk/
     HMPPS_COOKIE_NAME: hmpps-session-preprod
     API_DELIUS_ENDPOINT_URL: https://dps-and-delius-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,6 +14,7 @@ generic-service:
     HMPPS_MANAGE_USERS_API_URL: https://manage-users-api.hmpps.service.justice.gov.uk
     API_WHEREABOUTS_ENDPOINT_URL: https://whereabouts-api.service.justice.gov.uk/
     API_LOCATIONS_INSIDE_PRISON_ENDPOINT_URL: https://locations-inside-prison-api.hmpps.service.justice.gov.uk
+    API_NOMIS_MAPPING_ENDPOINT_URL: https://nomis-sync-prisoner-mapping.hmpps.service.justice.gov.uk
     LICENCES_URL: https://licences.prison.service.justice.gov.uk/
     HMPPS_COOKIE_NAME: hmpps-session-preprod
     API_DELIUS_ENDPOINT_URL: https://dps-and-delius.hmpps.service.justice.gov.uk

--- a/integration-tests/integration/health.cy.js
+++ b/integration-tests/integration/health.cy.js
@@ -48,6 +48,8 @@ context('Health page reports health correctly', () => {
         offenderSearch: 'UP',
         complexity: 'UP',
         incentivesApi: 'UP',
+        locationsInsidePrisonApi: 'UP',
+        nomisMapping: 'UP',
       })
     })
   })

--- a/integration-tests/integration/health.cy.js
+++ b/integration-tests/integration/health.cy.js
@@ -21,6 +21,8 @@ context('Health page reports health correctly', () => {
         offenderSearch: 'UP',
         complexity: 'UP',
         incentivesApi: 'UP',
+        locationsInsidePrisonApi: 'UP',
+        nomisMapping: 'UP',
       })
     })
   })

--- a/integration-tests/mockApis/nomisMapping.js
+++ b/integration-tests/mockApis/nomisMapping.js
@@ -1,0 +1,17 @@
+const { stubFor } = require('./wiremock')
+
+module.exports = {
+  stubHealth: () =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: '/nomis-mapping/health/ping',
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+        },
+      },
+    })
+}


### PR DESCRIPTION
The whereabouts API works using NOMIS location ids.
The BVLS API works using LocationsAPI location ids.

Up until now, we have assumed that the locationPrefix of a nomis location is equal to the business key of the locations returned from Locations API. However, this assumption is not always the case, namely at HMP Thameside.

Nomis location ids (fetched from Whereabouts API) must be mapped to DPS location keys using the NomisMapping tool provided by Syscon, for use when communicating with BVLS API and vice versa