### PR TITLE
BAVL-572 & BAVL-573: Include location when mapping an appointment to a video link booking, and fix added by field for probation users

### DIFF
--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -323,6 +323,7 @@ const setup = ({
       whereaboutsApi,
       locationsInsidePrisonApi,
       bookAVideoLinkApi,
+      nomisMapping,
     })
   )
 

--- a/backend/services/appointmentDetailsService.ts
+++ b/backend/services/appointmentDetailsService.ts
@@ -49,9 +49,6 @@ export default ({
 
     const prepostData = {}
 
-    let addedBy
-    let courtLocation
-
     const createLocationAndTimeString = (appt) =>
       `${locationTypes.find((loc) => Number(loc.locationId) === Number(appt.locationId)).userDescription} - ${getTime(
         appt.startTime
@@ -100,21 +97,23 @@ export default ({
           endTime: postAppointment.endTime,
         })
       }
-
-      addedBy = await (!vlb.createdByPrison ? 'Court' : getAddedByUser(res, vlb.createdBy))
-      courtLocation = vlb.courtDescription
     } else {
       locationType = locationTypes?.find((loc) => Number(loc.locationId) === Number(appointment.locationId))
     }
 
+    const getAddedBy = () => {
+      if (vlb && !vlb.createdByPrison) return vlb.bookingType === 'COURT' ? 'Court' : 'Probation team'
+      return vlb ? getAddedByUser(res, vlb.createdBy) : getAddedByUser(res, appointment.createUserId)
+    }
+
     const additionalDetails = {
-      courtLocation,
+      courtLocation: vlb?.courtDescription,
       probationTeam: vlb?.probationTeamDescription,
       meetingType: vlb?.probationMeetingTypeDescription,
       hearingType: vlb?.courtHearingTypeDescription,
       courtHearingLink: vlb && vlb.bookingType === 'COURT' ? vlb.videoLinkUrl || 'Not yet known' : undefined,
       comments: vlb?.comments || appointment.comment || 'Not entered',
-      addedBy: addedBy || (await getAddedByUser(res, appointment.createUserId)),
+      addedBy: await getAddedBy(),
     }
 
     const basicDetails = {

--- a/backend/tests/appointmentDetails.test.ts
+++ b/backend/tests/appointmentDetails.test.ts
@@ -240,6 +240,7 @@ describe('appointment details', () => {
         }
 
         videoLinkBooking = {
+          bookingType: 'COURT',
           courtDescription: 'Nottingham Justice Centre',
           courtHearingTypeDescription: 'Appeal',
           prisonAppointments: [
@@ -266,6 +267,7 @@ describe('appointment details', () => {
             additionalDetails: {
               courtLocation: 'Nottingham Justice Centre',
               hearingType: 'Appeal',
+              courtHearingLink: 'Not yet known',
               comments: 'VLB comments',
               addedBy: 'Court',
             },

--- a/backend/tests/viewAppointmentsController.test.ts
+++ b/backend/tests/viewAppointmentsController.test.ts
@@ -16,6 +16,7 @@ describe('View appointments', () => {
     getSearchGroups: jest.fn(),
   }
   const bookAVideoLinkApi = { getPrisonSchedule: jest.fn() }
+  const nomisMapping = { getNomisLocationMappingByDpsLocationId: jest.fn() }
   const systemOauthClient = {
     getClientCredentialsTokens: jest.fn(),
   }
@@ -78,6 +79,7 @@ describe('View appointments', () => {
       whereaboutsApi,
       locationsInsidePrisonApi,
       bookAVideoLinkApi,
+      nomisMapping,
     })
   })
 
@@ -210,7 +212,7 @@ describe('View appointments', () => {
           appointmentTypeDescription: 'Video Link booking',
           appointmentTypeCode: 'VLB',
           locationDescription: 'VCC ROOM',
-          locationId: 789,
+          locationId: 456,
           auditUserId: 'STAFF_3',
           agencyId: 'MDI',
         },
@@ -255,7 +257,7 @@ describe('View appointments', () => {
           appointmentTypeDescription: 'Video Link booking',
           appointmentTypeCode: 'VLB',
           locationDescription: 'VCC ROOM',
-          locationId: 456,
+          locationId: 789,
           auditUserId: 'STAFF_3',
           agencyId: 'MDI',
         },
@@ -299,6 +301,7 @@ describe('View appointments', () => {
           startTime: '14:30',
           endTime: '15:30',
           courtDescription: 'Wimbledon',
+          dpsLocationId: 'abc-123',
         },
         {
           videoBookingId: 1,
@@ -307,6 +310,7 @@ describe('View appointments', () => {
           startTime: '15:30',
           endTime: '15:45',
           courtDescription: 'Wimbledon',
+          dpsLocationId: 'abc-123',
         },
         {
           videoBookingId: 2,
@@ -315,6 +319,7 @@ describe('View appointments', () => {
           startTime: '15:45',
           endTime: '16:45',
           probationTeamDescription: 'Rotherham',
+          dpsLocationId: 'zyx-321',
         },
         {
           videoBookingId: 3,
@@ -325,6 +330,14 @@ describe('View appointments', () => {
           probationTeamDescription: 'Rotherham',
         },
       ])
+
+      nomisMapping.getNomisLocationMappingByDpsLocationId.mockImplementation(
+        async (_, id) =>
+          ({
+            'abc-123': { dpsLocationId: 'abc-123', nomisLocationId: 456 },
+            'zyx-321': { dpsLocationId: 'zyx-321', nomisLocationId: 789 },
+          }[id])
+      )
 
       req.query = {
         date: '02/01/2020',

--- a/integration-tests/integration/appointments/viewAppointments.cy.js
+++ b/integration-tests/integration/appointments/viewAppointments.cy.js
@@ -66,14 +66,16 @@ context('A user can view list of appointments', () => {
       {
         videoBookingId: 1,
         prisonAppointmentId: 1,
-        bookingType: "COURT",
-        statusCode: "ACTIVE",
-        courtDescription: "Wimbledon",
-        prisonerNumber: "ABC789",
-        startTime: "14:30",
-        endTime: "15:30",
-      }
+        bookingType: 'COURT',
+        statusCode: 'ACTIVE',
+        courtDescription: 'Wimbledon',
+        prisonerNumber: 'ABC789',
+        startTime: '14:30',
+        endTime: '15:30',
+        dpsLocationId: 'abc-123',
+      },
     ])
+    cy.task('stubNomisLocationMapping', { nomisLocationId: 789, dpsLocationId: 'abc-123' })
 
     cy.task('stubAppointmentLocations', {
       agency: 'MDI',


### PR DESCRIPTION
* Fix issue where bookings were being mismatched between Whereabouts and BVLS
* Fix issue where probation bookings would say `Added by: Court`