### PR TITLE
BAVL-901 small content changes for the BVLS court and probation appointments containing notes.

### DIFF
--- a/backend/services/appointmentDetailsService.ts
+++ b/backend/services/appointmentDetailsService.ts
@@ -180,8 +180,8 @@ export default ({
     // The comments field remains so that all other non-BVLS appointments only show the appointment comments
     const additionalDetailsWithPublicPrivateNotes = {
       courtHearingLink: vlb && vlb.bookingType === 'COURT' ? vlb.videoLinkUrl || 'Not yet known' : undefined,
-      notesForStaff: vlb ? vlb?.notesForStaff || 'Not entered' : undefined,
-      notesForPrisoners: vlb ? vlb?.notesForPrisoners || 'Not entered' : undefined,
+      notesForStaff: vlb ? vlb?.notesForStaff || 'None entered' : undefined,
+      notesForPrisoners: vlb ? vlb?.notesForPrisoners || 'None entered' : undefined,
       comments: vlb ? undefined : appointment.comment || 'Not entered',
       addedBy: await getAddedBy(),
     }

--- a/backend/tests/appointmentDetailsService.test.ts
+++ b/backend/tests/appointmentDetailsService.test.ts
@@ -303,8 +303,8 @@ describe('appointment details', () => {
       expect(appointmentDetails).toMatchObject({
         additionalDetails: {
           courtHearingLink: 'Not yet known',
-          notesForStaff: 'Not entered',
-          notesForPrisoners: 'Not entered',
+          notesForStaff: 'None entered',
+          notesForPrisoners: 'None entered',
           addedBy: 'Court',
         },
         basicDetails: {


### PR DESCRIPTION
Small content change for BLVS appointments to show 'None entered' instead of 'Not entered' for notes when none present for consistency across services.