### PR TITLE
BAVL-901 BVLS label changes for notes for VLB and VLPM appointment types.

### DIFF
--- a/backend/services/appointmentDetailsService.ts
+++ b/backend/services/appointmentDetailsService.ts
@@ -180,8 +180,8 @@ export default ({
     // The comments field remains so that all other non-BVLS appointments only show the appointment comments
     const additionalDetailsWithPublicPrivateNotes = {
       courtHearingLink: vlb && vlb.bookingType === 'COURT' ? vlb.videoLinkUrl || 'Not yet known' : undefined,
-      notesForStaff: vlb ? vlb?.notesForStaff || 'None entered' : undefined,
-      notesForPrisoners: vlb ? vlb?.notesForPrisoners || 'None entered' : undefined,
+      notesForPrisonStaff: vlb ? vlb?.notesForStaff || 'None entered' : undefined,
+      notesForPrisoner: vlb ? vlb?.notesForPrisoners || 'None entered' : undefined,
       comments: vlb ? undefined : appointment.comment || 'Not entered',
       addedBy: await getAddedBy(),
     }

--- a/backend/tests/appointmentDetailsService.test.ts
+++ b/backend/tests/appointmentDetailsService.test.ts
@@ -303,8 +303,8 @@ describe('appointment details', () => {
       expect(appointmentDetails).toMatchObject({
         additionalDetails: {
           courtHearingLink: 'Not yet known',
-          notesForStaff: 'None entered',
-          notesForPrisoners: 'None entered',
+          notesForPrisonStaff: 'None entered',
+          notesForPrisoner: 'None entered',
           addedBy: 'Court',
         },
         basicDetails: {


### PR DESCRIPTION
Small adjustment to the labels for BVLS appointment types on the appointment details screen.